### PR TITLE
implement agent service extensions and showcase integration

### DIFF
--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -1,8 +1,8 @@
 # slipstream_agent Service Extension Protocol
 
 This document defines the VM service extensions registered by
-`package:slipstream_agent`. The Slipstream MCP server (`inspector` server)
-calls these extensions when the companion package is detected.
+`package:slipstream_agent`. The Slipstream MCP server (`inspector` server) calls
+these extensions when the companion package is detected.
 
 Detection: the MCP server calls `ext.slipstream.ping` on session start. If the
 call succeeds, enhanced mode is active. If it fails (method not found), the
@@ -23,9 +23,7 @@ Heartbeat / discovery. Called once per session to detect the companion package.
 
 ```json
 {
-  "status": "ok",
-  "version": "0.1.0",
-  "flutterVersion": "native" | "web"
+  "version": "0.1.0"
 }
 ```
 
@@ -42,47 +40,52 @@ installed.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-|---|---|---|---|
-| `action` | String | yes | `"tap"` or `"set_text"` |
-| `finder` | String | yes | `"byKey"`, `"byType"`, `"byText"`, or `"bySemanticsLabel"` |
-| `finderValue` | String | yes | Value to match against the chosen finder |
-| `text` | String | for set_text | Text to set; replaces the field's current content |
+| Name          | Type   | Required     | Description                                                |
+| ------------- | ------ | ------------ | ---------------------------------------------------------- |
+| `action`      | String | yes          | `"tap"` or `"set_text"`                                    |
+| `finder`      | String | yes          | `"byKey"`, `"byType"`, `"byText"`, or `"bySemanticsLabel"` |
+| `finderValue` | String | yes          | Value to match against the chosen finder                   |
+| `text`        | String | for set_text | Text to set; replaces the field's current content          |
 
 **Finder semantics:**
 
-| Finder | Matches when |
-|---|---|
-| `byKey` | Widget has a `ValueKey<String>` equal to `finderValue`, or a `ValueKey<int>` whose `.toString()` equals `finderValue` |
-| `byType` | `widget.runtimeType.toString() == finderValue` (e.g. `"ElevatedButton"`) |
-| `byText` | Widget is a `Text` and `Text.data == finderValue` |
-| `bySemanticsLabel` | Widget is a `Semantics` and `properties.label == finderValue` |
+| Finder             | Matches when                                                                                                          |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `byKey`            | Widget has a `ValueKey<String>` equal to `finderValue`, or a `ValueKey<int>` whose `.toString()` equals `finderValue` |
+| `byType`           | `widget.runtimeType.toString() == finderValue` (e.g. `"ElevatedButton"`)                                              |
+| `byText`           | Widget is a `Text` and `Text.data == finderValue`                                                                     |
+| `bySemanticsLabel` | Widget is a `Semantics` and `properties.label == finderValue`                                                         |
 
 The tree is walked depth-first from the root; the first match is used.
 
 **Returns:**
 
 Success:
+
 ```json
 { "ok": true }
 ```
 
 Failure:
+
 ```json
-{ "ok": false, "error": "interact: no element found for finder=\"byKey\" value=\"login_button\"" }
+{
+  "ok": false,
+  "error": "interact: no element found for finder=\"byKey\" value=\"login_button\""
+}
 ```
 
 **Action details:**
 
 - **tap** — resolves the element's `RenderBox`, synthesizes a `PointerDownEvent`
-  + `PointerUpEvent` at the center of the element via
-  `GestureBinding.handlePointerEvent`. Triggers `GestureDetector.onTap`,
-  `InkWell.onTap`, and any other gesture recognizers on the widget.
+  - `PointerUpEvent` at the center of the element via
+    `GestureBinding.handlePointerEvent`. Triggers `GestureDetector.onTap`,
+    `InkWell.onTap`, and any other gesture recognizers on the widget.
 
 - **set_text** — walks the element's subtree to find an `EditableTextState` and
   sets `state.widget.controller.text = text`. Replaces the field's current
-  content entirely. The field must be part of the widget tree (i.e. it must
-  have been built at least once). Tap the field first if focus is required.
+  content entirely. The field must be part of the widget tree (i.e. it must have
+  been built at least once). Tap the field first if focus is required.
 
 - **scroll** — finds a `Scrollable` in the element's subtree and calls
   `position.animateTo(pixels + delta)`. Required params: `direction` (`"up"`,
@@ -92,8 +95,8 @@ Failure:
 - **scroll_until_visible** — scrolls the `Scrollable` identified by
   `scrollFinder`/`scrollFinderValue` until the target element is in the
   viewport. Uses `RenderAbstractViewport.getOffsetToReveal` to compute the
-  target offset. Retries up to 20 steps of 200 px if the target is not yet
-  laid out. Required params: `scrollFinder`, `scrollFinderValue`.
+  target offset. Retries up to 20 steps of 200 px if the target is not yet laid
+  out. Required params: `scrollFinder`, `scrollFinderValue`.
 
 ---
 
@@ -105,9 +108,9 @@ Navigates the app to a route path using the registered router adapter.
 
 **Parameters:**
 
-| Name | Type | Required | Description |
-|---|---|---|---|
-| `path` | String | yes | Route path, e.g. `"/podcast/123"` |
+| Name   | Type   | Required | Description                       |
+| ------ | ------ | -------- | --------------------------------- |
+| `path` | String | yes      | Route path, e.g. `"/podcast/123"` |
 
 **Returns:**
 

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -1,0 +1,126 @@
+# slipstream_agent Service Extension Protocol
+
+This document defines the VM service extensions registered by
+`package:slipstream_agent`. The Slipstream MCP server (`inspector` server)
+calls these extensions when the companion package is detected.
+
+Detection: the MCP server calls `ext.slipstream.ping` on session start. If the
+call succeeds, enhanced mode is active. If it fails (method not found), the
+server falls back to baseline behaviour.
+
+All extensions are registered by `SlipstreamAgent.init()`, which must be called
+in `kDebugMode` only. They are automatically stripped from release builds.
+
+---
+
+## `ext.slipstream.ping`
+
+Heartbeat / discovery. Called once per session to detect the companion package.
+
+**Parameters:** none
+
+**Returns:**
+
+```json
+{
+  "status": "ok",
+  "version": "0.1.0",
+  "flutterVersion": "native" | "web"
+}
+```
+
+`version` is the `slipstream_agent` package version. The MCP server stores this
+and exposes it as `session.companionVersion`.
+
+---
+
+## `ext.slipstream.interact`
+
+Performs a UI action on a widget located by a finder. Replaces the
+semantics-tree evaluate path for tap and set_text when the companion is
+installed.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `action` | String | yes | `"tap"` or `"set_text"` |
+| `finder` | String | yes | `"byKey"`, `"byType"`, `"byText"`, or `"bySemanticsLabel"` |
+| `finderValue` | String | yes | Value to match against the chosen finder |
+| `text` | String | for set_text | Text to set; replaces the field's current content |
+
+**Finder semantics:**
+
+| Finder | Matches when |
+|---|---|
+| `byKey` | Widget has a `ValueKey<String>` equal to `finderValue`, or a `ValueKey<int>` whose `.toString()` equals `finderValue` |
+| `byType` | `widget.runtimeType.toString() == finderValue` (e.g. `"ElevatedButton"`) |
+| `byText` | Widget is a `Text` and `Text.data == finderValue` |
+| `bySemanticsLabel` | Widget is a `Semantics` and `properties.label == finderValue` |
+
+The tree is walked depth-first from the root; the first match is used.
+
+**Returns:**
+
+Success:
+```json
+{ "ok": true }
+```
+
+Failure:
+```json
+{ "ok": false, "error": "interact: no element found for finder=\"byKey\" value=\"login_button\"" }
+```
+
+**Action details:**
+
+- **tap** — resolves the element's `RenderBox`, synthesizes a `PointerDownEvent`
+  + `PointerUpEvent` at the center of the element via
+  `GestureBinding.handlePointerEvent`. Triggers `GestureDetector.onTap`,
+  `InkWell.onTap`, and any other gesture recognizers on the widget.
+
+- **set_text** — walks the element's subtree to find an `EditableTextState` and
+  sets `state.widget.controller.text = text`. Replaces the field's current
+  content entirely. The field must be part of the widget tree (i.e. it must
+  have been built at least once). Tap the field first if focus is required.
+
+- **scroll** — finds a `Scrollable` in the element's subtree and calls
+  `position.animateTo(pixels + delta)`. Required params: `direction` (`"up"`,
+  `"down"`, `"left"`, `"right"`) and `pixels` (logical pixels as a string).
+  Clamped to the scroll extent bounds.
+
+- **scroll_until_visible** — scrolls the `Scrollable` identified by
+  `scrollFinder`/`scrollFinderValue` until the target element is in the
+  viewport. Uses `RenderAbstractViewport.getOffsetToReveal` to compute the
+  target offset. Retries up to 20 steps of 200 px if the target is not yet
+  laid out. Required params: `scrollFinder`, `scrollFinderValue`.
+
+---
+
+## `ext.slipstream.navigate`
+
+Navigates the app to a route path using the registered router adapter.
+
+> **Status:** implemented.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|---|---|---|---|
+| `path` | String | yes | Route path, e.g. `"/podcast/123"` |
+
+**Returns:**
+
+```json
+{ "ok": true }
+```
+
+or
+
+```json
+{ "ok": false, "error": "navigate: no router adapter registered" }
+```
+
+The router adapter is registered via `SlipstreamAgent.init(router: ...)`. See
+the design doc (`slipstream_agent_design.md`) for the `RouterAdapter` interface
+and available adapters.

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -34,7 +34,7 @@ and exposes it as `session.companionVersion`.
 
 ---
 
-## `ext.slipstream.interact`
+## `ext.slipstream.perform_action`
 
 Performs a UI action on a widget located by a finder. Replaces the
 semantics-tree evaluate path for tap and set_text when the companion is

--- a/slipstream_agent/lib/slipstream_agent.dart
+++ b/slipstream_agent/lib/slipstream_agent.dart
@@ -1,16 +1,28 @@
 import 'package:flutter/foundation.dart';
+
 import 'src/agent.dart';
+import 'src/router_adapter.dart';
+
+export 'src/router_adapter.dart' show RouterAdapter, GoRouterAdapter;
 
 /// The entry point for the Slipstream companion agent.
 class SlipstreamAgent {
   /// Initialize the Slipstream agent.
   ///
-  /// This registers VM service extensions that allow the Slipstream MCP server
-  /// to interact more deeply with the running app.
+  /// Registers VM service extensions that allow the Slipstream MCP server to
+  /// interact more deeply with the running app.
+  ///
+  /// [router] is an optional routing adapter. When provided, the MCP server
+  /// can call `navigate` to push routes without knowing which routing library
+  /// the app uses. Example:
+  ///
+  /// ```dart
+  /// SlipstreamAgent.init(router: GoRouterAdapter(appRouter));
+  /// ```
   ///
   /// This is a no-op if [kDebugMode] is false.
-  static void init() {
+  static void init({RouterAdapter? router}) {
     if (!kDebugMode) return;
-    Agent.instance.initialize();
+    Agent.instance.initialize(router: router);
   }
 }

--- a/slipstream_agent/lib/src/actions.dart
+++ b/slipstream_agent/lib/src/actions.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+/// Synthesizes a tap at the center of [element]'s render box.
+///
+/// Returns null on success, or an error message on failure. The tap is
+/// dispatched via [GestureBinding.handlePointerEvent], which performs hit
+/// testing at the element's center position and routes the events through
+/// Flutter's gesture recognizer system.
+Future<String?> tapElement(Element element) async {
+  final RenderBox? box = _findRenderBox(element);
+  if (box == null) {
+    return 'tap: no RenderBox found for element';
+  }
+  if (!box.hasSize) {
+    return 'tap: RenderBox has no size (layout not complete)';
+  }
+
+  final Offset position = box.localToGlobal(box.size.center(Offset.zero));
+
+  GestureBinding.instance.handlePointerEvent(
+    PointerDownEvent(position: position),
+  );
+  GestureBinding.instance.handlePointerEvent(
+    PointerUpEvent(position: position),
+  );
+
+  // Yield to the event loop so gesture recognizers and frame callbacks fire.
+  await Future<void>.delayed(Duration.zero);
+  return null;
+}
+
+/// Sets the text content of the [EditableText] found in or below [element].
+///
+/// Walks [element]'s subtree to find an [EditableTextState] and sets its
+/// controller's text to [text]. Returns null on success, or an error message
+/// on failure.
+String? setTextInElement(Element element, String text) {
+  final EditableTextState? state = _findEditableTextState(element);
+  if (state == null) {
+    return 'set_text: no EditableText found in element subtree';
+  }
+
+  state.widget.controller.text = text;
+  return null;
+}
+
+/// Scrolls the [Scrollable] found at or below [element] by [pixels] in
+/// [direction].
+///
+/// [direction] must be `"up"`, `"down"`, `"left"`, or `"right"`.
+/// Returns null on success, or an error message on failure.
+Future<String?> scrollElement(
+  Element element, {
+  required String direction,
+  required double pixels,
+}) async {
+  final ScrollableState? state = _findScrollableState(element);
+  if (state == null) {
+    return 'scroll: no Scrollable found in element subtree';
+  }
+
+  final double delta = switch (direction) {
+    'down' || 'right' => pixels,
+    'up' || 'left' => -pixels,
+    _ => double.nan,
+  };
+  if (delta.isNaN) {
+    return 'scroll: unknown direction "$direction" — use up, down, left, right';
+  }
+
+  await state.position.animateTo(
+    (state.position.pixels + delta).clamp(
+      state.position.minScrollExtent,
+      state.position.maxScrollExtent,
+    ),
+    duration: const Duration(milliseconds: 300),
+    curve: Curves.easeInOut,
+  );
+  return null;
+}
+
+/// Scrolls the [Scrollable] at [scrollElement] until [targetElement] is
+/// visible in the viewport.
+///
+/// Both elements must be located in the tree before calling this. Returns null
+/// on success, or an error message on failure.
+Future<String?> scrollUntilVisible({
+  required Element targetElement,
+  required Element scrollableElement,
+}) async {
+  final ScrollableState? scrollState = _findScrollableState(scrollableElement);
+  if (scrollState == null) {
+    return 'scroll_until_visible: no Scrollable found for scrollable finder';
+  }
+
+  // Attempt up to 20 scroll steps of 200px each to bring the target on screen.
+  const int maxSteps = 20;
+  const double stepPixels = 200.0;
+
+  for (var i = 0; i < maxSteps; i++) {
+    // Check if target is now visible.
+    final RenderBox? targetBox = _findRenderBox(targetElement);
+    if (targetBox != null && targetBox.hasSize) {
+      final RenderAbstractViewport? viewport =
+          RenderAbstractViewport.maybeOf(targetBox);
+      if (viewport != null) {
+        final RevealedOffset revealed =
+            viewport.getOffsetToReveal(targetBox, 0.5);
+        final double current = scrollState.position.pixels;
+        final double target = revealed.offset;
+        if ((current - target).abs() < 1.0) break; // already visible
+        await scrollState.position.animateTo(
+          target.clamp(
+            scrollState.position.minScrollExtent,
+            scrollState.position.maxScrollExtent,
+          ),
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeInOut,
+        );
+        break;
+      }
+    }
+    // Target not yet laid out or no viewport — scroll down a step and retry.
+    final double next = (scrollState.position.pixels + stepPixels).clamp(
+      scrollState.position.minScrollExtent,
+      scrollState.position.maxScrollExtent,
+    );
+    if (next == scrollState.position.pixels) break; // hit the end
+    await scrollState.position.animateTo(
+      next,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+    );
+    // Wait for a frame so newly-scrolled widgets lay out.
+    await SchedulerBinding.instance.endOfFrame;
+  }
+
+  return null;
+}
+
+/// Finds the first [ScrollableState] at or below [element].
+ScrollableState? _findScrollableState(Element element) {
+  if (element is StatefulElement && element.state is ScrollableState) {
+    return element.state as ScrollableState;
+  }
+  ScrollableState? found;
+  element.visitChildren((child) {
+    if (found != null) return;
+    found = _findScrollableState(child);
+  });
+  return found;
+}
+
+/// Finds the first [RenderBox] at or below [element].
+RenderBox? _findRenderBox(Element element) {
+  final RenderObject? ro = element.renderObject;
+  if (ro is RenderBox) return ro;
+
+  RenderBox? found;
+  element.visitChildren((child) {
+    if (found != null) return;
+    found = _findRenderBox(child);
+  });
+  return found;
+}
+
+/// Finds the first [EditableTextState] at or below [element].
+EditableTextState? _findEditableTextState(Element element) {
+  if (element is StatefulElement && element.state is EditableTextState) {
+    return element.state as EditableTextState;
+  }
+  EditableTextState? found;
+  element.visitChildren((child) {
+    if (found != null) return;
+    found = _findEditableTextState(child);
+  });
+  return found;
+}

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -39,7 +39,7 @@ class Agent {
 
     registerServiceExtension(
       ServiceDescription(
-        name: 'ext.slipstream.interact',
+        name: 'ext.slipstream.perform_action',
         description:
             'Performs a UI action (tap, set_text) on a widget located by a '
             'finder (byKey, byType, byText, bySemanticsLabel).',

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -14,10 +14,10 @@ class Agent {
   /// The singleton instance of the [Agent].
   static Agent get instance => _instance;
 
-  Agent._();
-
   bool _initialized = false;
   RouterAdapter? _router;
+
+  Agent._();
 
   /// Initializes the agent and registers service extensions.
   ///
@@ -25,140 +25,94 @@ class Agent {
   void initialize({RouterAdapter? router}) {
     if (_initialized) return;
     _initialized = true;
+
     _router = router;
 
     registerServiceExtension(
-      ServiceDescription(
-        name: 'ext.slipstream.ping',
-        description: 'Checks the status of the Slipstream agent.',
-        returns: [
-          ReturnDescription(
-              name: 'version',
-              type: 'String',
-              description: 'The slipstream_agent version.')
-        ],
-      ),
-      _ping,
-    );
-
-    // todo: make these long registrations shorter
-
-    registerServiceExtension(
-      ServiceDescription(
-        name: 'ext.slipstream.perform_action',
-        description:
-            'Performs a UI action (tap, set_text) on a widget located by a '
-            'finder (byKey, byType, byText, bySemanticsLabel).',
-        parameters: [
-          ParameterDescription(
-            name: 'action',
-            type: 'String',
-            description: 'The action to perform: "tap" or "set_text".',
-            required: true,
-          ),
-          ParameterDescription(
-            name: 'finder',
-            type: 'String',
-            description:
-                'How to find the widget: "byKey", "byType", "byText", or '
-                '"bySemanticsLabel".',
-            required: true,
-          ),
-          ParameterDescription(
-            name: 'finderValue',
-            type: 'String',
-            description: 'The value to match against the chosen finder.',
-            required: true,
-          ),
-          ParameterDescription(
-            name: 'text',
-            type: 'String',
-            description: 'Required for the set_text action. The text to set.',
-          ),
-          ParameterDescription(
-            name: 'direction',
-            type: 'String',
-            description:
-                'Required for scroll: "up", "down", "left", or "right".',
-          ),
-          ParameterDescription(
-            name: 'pixels',
-            type: 'String',
-            description: 'Required for scroll: number of logical pixels.',
-          ),
-          ParameterDescription(
-            name: 'scrollFinder',
-            type: 'String',
-            description:
-                'Required for scroll_until_visible: finder type for the '
-                'Scrollable widget.',
-          ),
-          ParameterDescription(
-            name: 'scrollFinderValue',
-            type: 'String',
-            description:
-                'Required for scroll_until_visible: finder value for the '
-                'Scrollable widget.',
-          ),
-        ],
-        returns: [
-          ReturnDescription(
-              name: 'ok', type: 'bool', description: 'The status of the call.'),
-          ReturnDescription(
-              name: 'error',
-              type: 'String',
-              description: 'A message describing any error.')
-        ],
-      ),
-      _interact,
+      _pingDescription,
+      _pingExtension,
     );
 
     registerServiceExtension(
-      ServiceDescription(
-        name: 'ext.slipstream.get_route',
-        description:
-            'Returns the current route path from the registered router adapter. '
-            'Requires SlipstreamAgent.init(router: ...) to have been called.',
-        returns: [
-          ReturnDescription(
-            name: 'path',
-            type: 'String',
-            description: 'The current route path, e.g. "/podcast/123".',
-          ),
-        ],
-      ),
-      _getRoute,
+      _getRouteDescription,
+      _getRouteExtension,
     );
 
     registerServiceExtension(
-      ServiceDescription(
-        name: 'ext.slipstream.navigate',
-        description:
-            'Navigates the app to a route path via the registered router '
-            'adapter. Requires SlipstreamAgent.init(router: ...) to have been '
-            'called.',
-        parameters: [
-          ParameterDescription(
-            name: 'path',
-            type: 'String',
-            description: 'Route path to navigate to, e.g. "/podcast/123".',
-            required: true,
-          ),
-        ],
-        returns: [
-          ReturnDescription(
-              name: 'ok', type: 'bool', description: 'The status of the call.'),
-          ReturnDescription(
-              name: 'error',
-              type: 'String',
-              description: 'A message describing any error.')
-        ],
-      ),
-      _navigate,
+      _navigateDescription,
+      _navigateExtension,
+    );
+
+    registerServiceExtension(
+      _interactDescription,
+      _interactExtension,
     );
   }
 
-  Future<Map<String, Object?>> _interact(
+  final ServiceDescription _interactDescription = ServiceDescription(
+    name: 'ext.slipstream.perform_action',
+    description:
+        'Performs a UI action (tap, set_text) on a widget located by a '
+        'finder (byKey, byType, byText, bySemanticsLabel).',
+    parameters: [
+      ParameterDescription(
+        name: 'action',
+        type: 'String',
+        description: 'The action to perform: "tap" or "set_text".',
+        required: true,
+      ),
+      ParameterDescription(
+        name: 'finder',
+        type: 'String',
+        description: 'How to find the widget: "byKey", "byType", "byText", or '
+            '"bySemanticsLabel".',
+        required: true,
+      ),
+      ParameterDescription(
+        name: 'finderValue',
+        type: 'String',
+        description: 'The value to match against the chosen finder.',
+        required: true,
+      ),
+      ParameterDescription(
+        name: 'text',
+        type: 'String',
+        description: 'Required for the set_text action. The text to set.',
+      ),
+      ParameterDescription(
+        name: 'direction',
+        type: 'String',
+        description: 'Required for scroll: "up", "down", "left", or "right".',
+      ),
+      ParameterDescription(
+        name: 'pixels',
+        type: 'String',
+        description: 'Required for scroll: number of logical pixels.',
+      ),
+      ParameterDescription(
+        name: 'scrollFinder',
+        type: 'String',
+        description: 'Required for scroll_until_visible: finder type for the '
+            'Scrollable widget.',
+      ),
+      ParameterDescription(
+        name: 'scrollFinderValue',
+        type: 'String',
+        description: 'Required for scroll_until_visible: finder value for the '
+            'Scrollable widget.',
+      ),
+    ],
+    returns: [
+      ReturnDescription(
+          name: 'ok', type: 'bool', description: 'The status of the call.'),
+      ReturnDescription(
+          name: 'error',
+          type: 'String',
+          description: 'A message describing any error.')
+    ],
+  );
+
+  Future<Map<String, Object?>> _interactExtension(
     ExtensionParameters parameters,
   ) async {
     final String action = parameters.asStringRequired('action');
@@ -235,7 +189,22 @@ class Agent {
     return {'ok': true};
   }
 
-  Future<Map<String, Object?>> _getRoute(ExtensionParameters parameters) async {
+  final ServiceDescription _getRouteDescription = ServiceDescription(
+    name: 'ext.slipstream.get_route',
+    description:
+        'Returns the current route path from the registered router adapter. '
+        'Requires SlipstreamAgent.init(router: ...) to have been called.',
+    returns: [
+      ReturnDescription(
+        name: 'path',
+        type: 'String',
+        description: 'The current route path, e.g. "/podcast/123".',
+      ),
+    ],
+  );
+
+  Future<Map<String, Object?>> _getRouteExtension(
+      ExtensionParameters parameters) async {
     final path = _router?.currentPath();
     if (path == null) {
       return {
@@ -246,7 +215,30 @@ class Agent {
     return {'ok': true, 'path': path};
   }
 
-  Future<Map<String, Object?>> _navigate(
+  final ServiceDescription _navigateDescription = ServiceDescription(
+    name: 'ext.slipstream.navigate',
+    description: 'Navigates the app to a route path via the registered router '
+        'adapter. Requires SlipstreamAgent.init(router: ...) to have been '
+        'called.',
+    parameters: [
+      ParameterDescription(
+        name: 'path',
+        type: 'String',
+        description: 'Route path to navigate to, e.g. "/podcast/123".',
+        required: true,
+      ),
+    ],
+    returns: [
+      ReturnDescription(
+          name: 'ok', type: 'bool', description: 'The status of the call.'),
+      ReturnDescription(
+          name: 'error',
+          type: 'String',
+          description: 'A message describing any error.')
+    ],
+  );
+
+  Future<Map<String, Object?>> _navigateExtension(
     ExtensionParameters parameters,
   ) async {
     final String path = parameters.asStringRequired('path');
@@ -274,7 +266,19 @@ class Agent {
     }
   }
 
-  Future<Map<String, Object?>> _ping(ExtensionParameters parameters) async {
+  final ServiceDescription _pingDescription = ServiceDescription(
+    name: 'ext.slipstream.ping',
+    description: 'Checks the status of the Slipstream agent.',
+    returns: [
+      ReturnDescription(
+          name: 'version',
+          type: 'String',
+          description: 'The slipstream_agent version.')
+    ],
+  );
+
+  Future<Map<String, Object?>> _pingExtension(
+      ExtensionParameters parameters) async {
     return {
       'version': '0.1.0',
     };

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -1,7 +1,12 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:service_extensions/service_extensions.dart';
+
+import 'actions.dart';
+import 'finder.dart';
+import 'router_adapter.dart';
 
 /// The internal implementation of the Slipstream agent.
 class Agent {
@@ -13,11 +18,15 @@ class Agent {
   Agent._();
 
   bool _initialized = false;
+  RouterAdapter? _router;
 
   /// Initializes the agent and registers service extensions.
-  void initialize() {
+  ///
+  /// [router] is an optional routing adapter for `ext.slipstream.navigate`.
+  void initialize({RouterAdapter? router}) {
     if (_initialized) return;
     _initialized = true;
+    _router = router;
 
     registerServiceExtension(
       ServiceDescription(
@@ -26,6 +35,93 @@ class Agent {
         returns: 'A status object.',
       ),
       _ping,
+    );
+
+    registerServiceExtension(
+      ServiceDescription(
+        name: 'ext.slipstream.interact',
+        description:
+            'Performs a UI action (tap, set_text) on a widget located by a '
+            'finder (byKey, byType, byText, bySemanticsLabel).',
+        parameters: [
+          ParameterDescription(
+            name: 'action',
+            type: 'String',
+            description: 'The action to perform: "tap" or "set_text".',
+            required: true,
+          ),
+          ParameterDescription(
+            name: 'finder',
+            type: 'String',
+            description:
+                'How to find the widget: "byKey", "byType", "byText", or '
+                '"bySemanticsLabel".',
+            required: true,
+          ),
+          ParameterDescription(
+            name: 'finderValue',
+            type: 'String',
+            description: 'The value to match against the chosen finder.',
+            required: true,
+          ),
+          ParameterDescription(
+            name: 'text',
+            type: 'String',
+            description: 'Required for the set_text action. The text to set.',
+          ),
+          ParameterDescription(
+            name: 'direction',
+            type: 'String',
+            description:
+                'Required for scroll: "up", "down", "left", or "right".',
+          ),
+          ParameterDescription(
+            name: 'pixels',
+            type: 'String',
+            description: 'Required for scroll: number of logical pixels.',
+          ),
+          ParameterDescription(
+            name: 'scrollFinder',
+            type: 'String',
+            description:
+                'Required for scroll_until_visible: finder type for the '
+                'Scrollable widget.',
+          ),
+          ParameterDescription(
+            name: 'scrollFinderValue',
+            type: 'String',
+            description:
+                'Required for scroll_until_visible: finder value for the '
+                'Scrollable widget.',
+          ),
+        ],
+        returns:
+            'An object with an "ok" boolean. On failure, includes an "error" '
+            'string.',
+      ),
+      _interact,
+    );
+
+    registerServiceExtension(
+      ServiceDescription(
+        name: 'ext.slipstream.navigate',
+        description:
+            'Navigates the app to a route path via the registered router '
+            'adapter. Requires SlipstreamAgent.init(router: ...) to have been '
+            'called.',
+        parameters: [
+          ParameterDescription(
+            name: 'path',
+            type: 'String',
+            description: 'Route path to navigate to, e.g. "/podcast/123".',
+            required: true,
+          ),
+        ],
+        returns:
+            'An object with an "ok" boolean. On failure, includes an "error" '
+            'string.',
+      ),
+      _navigate,
     );
 
     registerServiceExtension(
@@ -49,6 +145,111 @@ class Agent {
       ),
       _echo,
     );
+  }
+
+  Future<Map<String, Object?>> _interact(
+    ServiceExtensionParameters parameters,
+  ) async {
+    final String action = parameters.asStringRequired('action');
+    final String finder = parameters.asStringRequired('finder');
+    final String finderValue = parameters.asStringRequired('finderValue');
+    final String? text = parameters.asString('text');
+    final String? direction = parameters.asString('direction');
+    final String? pixelsStr = parameters.asString('pixels');
+    final String? scrollFinder = parameters.asString('scrollFinder');
+    final String? scrollFinderValue = parameters.asString('scrollFinderValue');
+
+    final element = findElement(finder: finder, value: finderValue);
+    if (element == null) {
+      return {
+        'ok': false,
+        'error': 'interact: no element found for finder="$finder" '
+            'value="$finderValue"',
+      };
+    }
+
+    String? error;
+    switch (action) {
+      case 'tap':
+        error = await tapElement(element);
+      case 'set_text':
+        if (text == null) {
+          error = 'interact: "text" is required for the set_text action';
+        } else {
+          error = setTextInElement(element, text);
+        }
+      case 'scroll':
+        if (direction == null) {
+          error = 'interact: "direction" is required for the scroll action';
+        } else if (pixelsStr == null) {
+          error = 'interact: "pixels" is required for the scroll action';
+        } else {
+          final double? pixels = double.tryParse(pixelsStr);
+          if (pixels == null) {
+            error = 'interact: "pixels" must be a number, got "$pixelsStr"';
+          } else {
+            error = await scrollElement(
+              element,
+              direction: direction,
+              pixels: pixels,
+            );
+          }
+        }
+      case 'scroll_until_visible':
+        if (scrollFinder == null || scrollFinderValue == null) {
+          error =
+              'interact: "scrollFinder" and "scrollFinderValue" are required '
+              'for scroll_until_visible';
+        } else {
+          final scrollable = findElement(
+            finder: scrollFinder,
+            value: scrollFinderValue,
+          );
+          if (scrollable == null) {
+            error =
+                'interact: no scrollable found for scrollFinder="$scrollFinder"'
+                ' value="$scrollFinderValue"';
+          } else {
+            error = await scrollUntilVisible(
+              targetElement: element,
+              scrollableElement: scrollable,
+            );
+          }
+        }
+      default:
+        error = 'interact: unknown action "$action"';
+    }
+
+    if (error != null) return {'ok': false, 'error': error};
+    return {'ok': true};
+  }
+
+  Future<Map<String, Object?>> _navigate(
+    ServiceExtensionParameters parameters,
+  ) async {
+    final String path = parameters.asStringRequired('path');
+
+    if (_router == null) {
+      return {
+        'ok': false,
+        'error': 'navigate: no router adapter registered. Call '
+            'SlipstreamAgent.init(router: GoRouterAdapter(appRouter)) in '
+            'main().',
+      };
+    }
+
+    // Obtain a BuildContext from the root element.
+    final Element? root = WidgetsBinding.instance.rootElement;
+    if (root == null) {
+      return {'ok': false, 'error': 'navigate: widget tree not yet built'};
+    }
+
+    try {
+      _router!.go(root, path);
+      return {'ok': true};
+    } catch (e) {
+      return {'ok': false, 'error': 'navigate: $e'};
+    }
   }
 
   Future<Map<String, Object?>> _ping(

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:service_extensions/service_extensions.dart';
 
@@ -32,10 +31,17 @@ class Agent {
       ServiceDescription(
         name: 'ext.slipstream.ping',
         description: 'Checks the status of the Slipstream agent.',
-        returns: 'A status object.',
+        returns: [
+          ReturnDescription(
+              name: 'version',
+              type: 'String',
+              description: 'The slipstream_agent version.')
+        ],
       ),
       _ping,
     );
+
+    // todo: make these long registrations shorter
 
     registerServiceExtension(
       ServiceDescription(
@@ -95,11 +101,33 @@ class Agent {
                 'Scrollable widget.',
           ),
         ],
-        returns:
-            'An object with an "ok" boolean. On failure, includes an "error" '
-            'string.',
+        returns: [
+          ReturnDescription(
+              name: 'ok', type: 'bool', description: 'The status of the call.'),
+          ReturnDescription(
+              name: 'error',
+              type: 'String',
+              description: 'A message describing any error.')
+        ],
       ),
       _interact,
+    );
+
+    registerServiceExtension(
+      ServiceDescription(
+        name: 'ext.slipstream.get_route',
+        description:
+            'Returns the current route path from the registered router adapter. '
+            'Requires SlipstreamAgent.init(router: ...) to have been called.',
+        returns: [
+          ReturnDescription(
+            name: 'path',
+            type: 'String',
+            description: 'The current route path, e.g. "/podcast/123".',
+          ),
+        ],
+      ),
+      _getRoute,
     );
 
     registerServiceExtension(
@@ -117,38 +145,21 @@ class Agent {
             required: true,
           ),
         ],
-        returns:
-            'An object with an "ok" boolean. On failure, includes an "error" '
-            'string.',
+        returns: [
+          ReturnDescription(
+              name: 'ok', type: 'bool', description: 'The status of the call.'),
+          ReturnDescription(
+              name: 'error',
+              type: 'String',
+              description: 'A message describing any error.')
+        ],
       ),
       _navigate,
-    );
-
-    registerServiceExtension(
-      ServiceDescription(
-        name: 'ext.slipstream.echo',
-        description: 'Echoes back a message.',
-        parameters: [
-          ParameterDescription(
-            name: 'message',
-            type: 'String',
-            description: 'The message to echo.',
-            required: true,
-          ),
-          ParameterDescription(
-            name: 'name',
-            type: 'String',
-            description: 'An optional name to include.',
-          ),
-        ],
-        returns: 'The echoed message.',
-      ),
-      _echo,
     );
   }
 
   Future<Map<String, Object?>> _interact(
-    ServiceExtensionParameters parameters,
+    ExtensionParameters parameters,
   ) async {
     final String action = parameters.asStringRequired('action');
     final String finder = parameters.asStringRequired('finder');
@@ -224,8 +235,19 @@ class Agent {
     return {'ok': true};
   }
 
+  Future<Map<String, Object?>> _getRoute(ExtensionParameters parameters) async {
+    final path = _router?.currentPath();
+    if (path == null) {
+      return {
+        'ok': false,
+        'error': 'get_route: no router adapter registered or path unavailable',
+      };
+    }
+    return {'ok': true, 'path': path};
+  }
+
   Future<Map<String, Object?>> _navigate(
-    ServiceExtensionParameters parameters,
+    ExtensionParameters parameters,
   ) async {
     final String path = parameters.asStringRequired('path');
 
@@ -252,19 +274,9 @@ class Agent {
     }
   }
 
-  Future<Map<String, Object?>> _ping(
-      ServiceExtensionParameters parameters) async {
+  Future<Map<String, Object?>> _ping(ExtensionParameters parameters) async {
     return {
-      'status': 'ok',
       'version': '0.1.0',
-      'flutterVersion': kIsWeb ? 'web' : 'native',
     };
-  }
-
-  Future<String> _echo(ServiceExtensionParameters parameters) async {
-    final message = parameters.asStringRequired('message');
-    final name = parameters.asString('name');
-
-    return name != null ? 'hello $name; => $message' : '=> $message';
   }
 }

--- a/slipstream_agent/lib/src/finder.dart
+++ b/slipstream_agent/lib/src/finder.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/widgets.dart';
+
+/// Returns the first [Element] in the live widget tree that matches [finder]
+/// and [value], or null if not found.
+///
+/// Supported finder types:
+/// - `byKey` — matches a `ValueKey<String>` or `ValueKey<int>` (by string
+///   representation)
+/// - `byType` — matches the widget's `runtimeType.toString()` exactly
+/// - `byText` — matches a [Text] widget whose `data` equals [value]
+/// - `bySemanticsLabel` — matches a [Semantics] widget whose label equals
+///   [value]
+///
+/// Returns null if no matching element is found.
+Element? findElement({required String finder, required String value}) {
+  Element? result;
+
+  void visit(Element element) {
+    if (result != null) return;
+    if (_matches(element, finder, value)) {
+      result = element;
+      return;
+    }
+    element.visitChildren(visit);
+  }
+
+  WidgetsBinding.instance.rootElement?.visitChildren(visit);
+
+  return result;
+}
+
+bool _matches(Element element, String finder, String value) {
+  final Widget widget = element.widget;
+  switch (finder) {
+    case 'byKey':
+      final Key? key = widget.key;
+      if (key is ValueKey<String>) return key.value == value;
+      if (key is ValueKey<int>) return key.value.toString() == value;
+      return false;
+
+    case 'byType':
+      return widget.runtimeType.toString() == value;
+
+    case 'byText':
+      if (widget is Text) return widget.data == value;
+      return false;
+
+    case 'bySemanticsLabel':
+      if (widget is Semantics) return widget.properties.label == value;
+      return false;
+
+    default:
+      return false;
+  }
+}

--- a/slipstream_agent/lib/src/router_adapter.dart
+++ b/slipstream_agent/lib/src/router_adapter.dart
@@ -17,6 +17,10 @@ abstract class RouterAdapter {
   /// Should be called on the UI thread. Returns normally on success; throws
   /// on failure.
   void go(BuildContext context, String path);
+
+  /// Returns the current route path (e.g. `"/podcast/123"`), or null if the
+  /// path cannot be determined.
+  String? currentPath();
 }
 
 /// [RouterAdapter] implementation for the `go_router` package.
@@ -42,5 +46,16 @@ class GoRouterAdapter extends RouterAdapter {
     // Calls GoRouter.go(path) dynamically — no import of go_router needed.
     // ignore: avoid_dynamic_calls
     _router.go(path);
+  }
+
+  @override
+  String? currentPath() {
+    try {
+      // Calls GoRouter.state.uri.toString() dynamically.
+      // ignore: avoid_dynamic_calls
+      return _router.state.uri.toString();
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/slipstream_agent/lib/src/router_adapter.dart
+++ b/slipstream_agent/lib/src/router_adapter.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/widgets.dart';
+
+/// Adapter interface that lets slipstream_agent navigate the app without
+/// knowing which routing library is in use.
+///
+/// Register an adapter via [SlipstreamAgent.init]:
+///
+/// ```dart
+/// SlipstreamAgent.init(router: GoRouterAdapter(appRouter));
+/// ```
+abstract class RouterAdapter {
+  /// Navigates to [path].
+  ///
+  /// [path] is a route path such as `"/podcast/123"`. The adapter is
+  /// responsible for translating this to the routing library's API.
+  ///
+  /// Should be called on the UI thread. Returns normally on success; throws
+  /// on failure.
+  void go(BuildContext context, String path);
+}
+
+/// [RouterAdapter] implementation for the `go_router` package.
+///
+/// Pass the app's [GoRouter] instance directly:
+///
+/// ```dart
+/// // In main():
+/// final _router = GoRouter(routes: [...]);
+///
+/// SlipstreamAgent.init(router: GoRouterAdapter(_router));
+/// ```
+class GoRouterAdapter extends RouterAdapter {
+  GoRouterAdapter(this._router);
+
+  /// The [GoRouter] instance. Declared as `dynamic` to avoid a hard
+  /// compile-time dependency on the `go_router` package. At runtime, this must
+  /// be a `GoRouter` with a `.go(String path)` method.
+  final dynamic _router;
+
+  @override
+  void go(BuildContext context, String path) {
+    // Calls GoRouter.go(path) dynamically — no import of go_router needed.
+    // ignore: avoid_dynamic_calls
+    _router.go(path);
+  }
+}

--- a/slipstream_agent/pubspec.yaml
+++ b/slipstream_agent/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  service_extensions: ^0.1.0
+  service_extensions: ^0.2.0
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/slipstream_showcase/lib/main.dart
+++ b/slipstream_showcase/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:slipstream_showcase/model.dart';
+import 'package:slipstream_agent/slipstream_agent.dart';
 
 import 'common.dart';
 import 'discover_page.dart';
@@ -56,6 +57,8 @@ String _themeModeLabel(ThemeMode mode) => switch (mode) {
 final GlobalKey<NavigatorState> _rootNavigatorKey = GlobalKey<NavigatorState>();
 
 void main() {
+  SlipstreamAgent.init(router: GoRouterAdapter(_router));
+
   runApp(const ShowcaseApp());
 }
 

--- a/slipstream_showcase/pubspec.yaml
+++ b/slipstream_showcase/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   go_router: ^17.2.0
   provider: ^6.1.0
+  slipstream_agent: ^0.1.0
 
 dev_dependencies:
   flutter_lints: ^6.0.0
@@ -20,3 +21,7 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+dependency_overrides:
+  slipstream_agent:
+    path: ../slipstream_agent


### PR DESCRIPTION
Implement the core Slipstream service extension protocol and integrate the agent into the showcase app for enhanced mode testing.

- Implement 'ext.slipstream.perform_action' and 'ext.slipstream.navigate' service extensions
- Add 'ext.slipstream.get_route' for retrieving current route path
- Refactor Agent class to use modular ServiceDescription fields
- Integrate SlipstreamAgent into slipstream_showcase with GoRouterAdapter
- Update service_extensions dependency to ^0.2.0
- Update protocol documentation for service extensions