### PR TITLE
perform_set_text: fire onChanged callback after setting text

### DIFF
--- a/slipstream_agent/lib/src/actions.dart
+++ b/slipstream_agent/lib/src/actions.dart
@@ -43,7 +43,14 @@ String? setTextInElement(Element element, String text) {
     return 'set_text: no EditableText found in element subtree';
   }
 
+  final String previous = state.widget.controller.text;
   state.widget.controller.text = text;
+  // Mirror the framework's _formatAndSetValue behaviour: fire onChanged when
+  // the text actually changed.  (TextInputFormatters are intentionally skipped
+  // since we bypass the input pipeline.)
+  if (text != previous) {
+    state.widget.onChanged?.call(text);
+  }
   return null;
 }
 


### PR DESCRIPTION
After setting `controller.text`, calls `EditableText.onChanged` when the value actually changed — mirrors the framework's `_formatAndSetValue` behaviour.

- `TextInputFormatter`s are intentionally skipped (text is set directly, bypassing the input pipeline)
- Fixes the issue described in devoncarew/flutter-slipstream#68