### PR TITLE
Prepare slipstream_agent 0.1.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,14 +36,14 @@ slipstream_showcase/ — a Flutter app that exercises the extensions manually
 All extensions are registered in `Agent.initialize()` (`lib/src/agent.dart`)
 using `registerServiceExtension()` from `package:service_extensions`.
 
-| Extension                         | Purpose                                                                |
-| --------------------------------- | ---------------------------------------------------------------------- |
-| `ext.slipstream.ping`             | Session detection; returns package version                             |
-| `ext.slipstream.perform_action`   | Tap, set_text, scroll, scroll_until_visible via element-tree finders   |
-| `ext.slipstream.navigate`         | Route navigation via the registered `RouterAdapter`                    |
-| `ext.slipstream.get_route`        | Current route path from the registered `RouterAdapter`                 |
-| `ext.slipstream.enable_semantics` | Calls `RendererBinding.instance.ensureSemantics()` + `scheduleFrame()` |
-| `ext.slipstream.get_semantics` | Returns visible semantics nodes with screen-space bounds (improved vs. out-of-process) |
+| Extension                         | Purpose                                                                                |
+| --------------------------------- | -------------------------------------------------------------------------------------- |
+| `ext.slipstream.ping`             | Session detection; returns package version                                             |
+| `ext.slipstream.perform_action`   | Tap, set_text, scroll, scroll_until_visible via element-tree finders                   |
+| `ext.slipstream.navigate`         | Route navigation via the registered `RouterAdapter`                                    |
+| `ext.slipstream.get_route`        | Current route path from the registered `RouterAdapter`                                 |
+| `ext.slipstream.enable_semantics` | Calls `RendererBinding.instance.ensureSemantics()` + `scheduleFrame()`                 |
+| `ext.slipstream.get_semantics`    | Returns visible semantics nodes with screen-space bounds (improved vs. out-of-process) |
 
 See `slipstream_agent/docs/service_extensions.md` for the full parameter and
 return-value spec for each extension.
@@ -54,10 +54,10 @@ In addition to request/response extensions, the agent posts events to the VM
 service `Extension` stream via `dart:developer.postEvent`. Clients subscribe
 with `streamListen('Extension')` and filter by `event.extensionKind`.
 
-| Event | Trigger | Source |
-| ----- | ------- | ------ |
-| `ext.slipstream.windowResized` | Window/display metrics change | `WidgetsBindingObserver.didChangeMetrics` |
-| `ext.slipstream.routeChanged` | Router navigates to a new path | `GoRouterAdapter` listener on the `GoRouter` `Listenable` |
+| Event                          | Trigger                        | Source                                                    |
+| ------------------------------ | ------------------------------ | --------------------------------------------------------- |
+| `ext.slipstream.windowResized` | Window/display metrics change  | `WidgetsBindingObserver.didChangeMetrics`                 |
+| `ext.slipstream.routeChanged`  | Router navigates to a new path | `GoRouterAdapter` listener on the `GoRouter` `Listenable` |
 
 Telemetry is initialized automatically by `Agent.initialize()` via
 `initTelemetry()` in `lib/src/telemetry.dart`. New events go in that file;
@@ -90,8 +90,8 @@ automatically tree-shaken from release builds.
 
 ## Core Principles
 
-- **Zero-config baseline:** The flutter_slipstream MCP server must remain fully
-  functional without this package installed. These extensions unlock _enhanced_
+- **Zero-config baseline:** The flutter*slipstream MCP server must remain fully
+  functional without this package installed. These extensions unlock \_enhanced*
   capabilities, never required ones.
 - **Debug-only:** Never call or register anything outside `kDebugMode`. No
   production leakage.
@@ -115,10 +115,10 @@ cd slipstream_agent && dart analyze
 
 ## Companion Project
 
-The MCP server that _calls_ these extensions lives in
-`/Users/devoncarew/projects/devoncarew/flutter_slipstream` (the
-`flutter_slipstream` repo). The design rationale, phasing plan, and full
-architectural context are in:
+The MCP server that _calls_ these extensions lives in `../flutter_slipstream` /
+https://github.com/devoncarew/flutter-slipstream (the `flutter_slipstream`
+repo). The design rationale, phasing plan, and full architectural context are
+in:
 
 - `flutter_slipstream/DESIGN.md` — overall plugin architecture
 - `flutter_slipstream/docs/slipstream_agent.md` — companion package design doc

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ tools.
 
 ## Packages
 
-| Package                                     | Description                                                                                                                                                                           |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [slipstream_agent](slipstream_agent/)       | An optional, opt-in `dev_dependency` that upgrades the connection between the Slipstream MCP server and your running Flutter app — from external observation to internal cooperation. |
-| [slipstream_showcase](slipstream_showcase/) | A sample Flutter app used for integration testing of the Flutter Slipstream MCP plugin.                                                                                               |
+| Package                                     | Description                                                                                                                                                                       |
+| ------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [slipstream_agent](slipstream_agent/)       | An optional, opt-in `dependency` that upgrades the connection between the Slipstream MCP server and your running Flutter app — from external observation to internal cooperation. |
+| [slipstream_showcase](slipstream_showcase/) | A sample Flutter app used for integration testing of the Flutter Slipstream MCP plugin.                                                                                           |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # slipstream_agent
 
 This repo contains two packages that together support the
-[Slipstream Flutter agent tools](https://github.com/devoncarew/flutter-agent-tools)
-MCP plugin.
+[Flutter Slipstream](https://github.com/devoncarew/flutter-slipstream) agent
+tools.
 
 ## Packages
 

--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,4 +1,26 @@
 ## 0.1.0
 
-- Initial version with `SlipstreamAgent.init()`.
-- Added the `ext.slipstream.ping` service extension for discovery.
+Initial release.
+
+- `SlipstreamAgent.init()` registers VM service extensions that the Flutter
+  Slipstream MCP server uses for enhanced app interaction. All extensions are
+  no-ops outside `kDebugMode` and are tree-shaken from release builds.
+- Service extensions registered:
+  - `ext.slipstream.ping` — session detection and version reporting
+  - `ext.slipstream.perform_action` — tap, set_text, scroll, and
+    scroll_until_visible via element-tree finders (`byKey`, `byType`, `byText`,
+    `bySemanticsLabel`)
+  - `ext.slipstream.enable_semantics` — enables the Flutter semantics tree
+  - `ext.slipstream.get_semantics` — returns visible semantics nodes as
+    structured JSON with screen-space bounds (more accurate than the
+    out-of-process evaluate-based implementation)
+  - `ext.slipstream.navigate` — navigates to a route path via the registered
+    `RouterAdapter`
+  - `ext.slipstream.get_route` — returns the current route path via the
+    registered `RouterAdapter`
+- Telemetry events posted to the VM service `Extension` stream:
+  - `ext.slipstream.windowResized` — fired on window/display metric changes
+  - `ext.slipstream.routeChanged` — fired on route changes (requires a
+    `RouterAdapter`)
+- `GoRouterAdapter` provides `go_router` support (but without a transitive
+  dependency on `package:go_router`).

--- a/slipstream_agent/README.md
+++ b/slipstream_agent/README.md
@@ -1,46 +1,97 @@
 # slipstream_agent
 
-An in-process companion package for
-[Flutter Slipstream](https://github.com/devoncarew/flutter-slipstream).
+An in-process companion package for the
+[Flutter Slipstream](https://github.com/devoncarew/flutter-slipstream) agent
+tools.
 
-`slipstream_agent` is an optional, opt-in `dev_dependency` that upgrades the
-connection between the Flutter Slipstream MCP server and your running app from
-external observation to internal cooperation.
+`package:slipstream_agent` is an optional, opt-in `dev_dependency` that upgrades
+the connection between the Flutter Slipstream MCP server and your running app —
+from external observation to internal cooperation.
+
+When the MCP server detects the package (via `ext.slipstream.ping`), it
+automatically routes tool calls through typed in-process extensions instead of
+fragile `evaluate` strings. If the package is not installed, all tools fall back
+silently to the baseline behavior.
 
 ## Features
 
-- **Advanced UI Finders:** Target widgets by `Key`, `Type`, or `Text` without
-  needing explicit `Semantics` annotations.
-- **Scroll Support:** Programmatically scroll off-screen content into view.
-- **Unified Routing:** Provides a uniform interface for programmatic navigation
-  across different routing libraries.
-- **Ghost Overlay:** Gives visual feedback in the app showing exactly what the
-  agent is currently targeting.
+- **Advanced UI finders:** Target widgets by `Key`, type, or text content
+  without requiring explicit `Semantics` annotations. Supported finders:
+  `byKey`, `byType`, `byText`, `bySemanticsLabel`.
+- **Scroll support:** Programmatically scroll by a fixed amount or scroll until
+  a target widget is visible.
+- **Semantics tree:** Enable the Flutter semantics tree and query visible nodes
+  with accurate screen-space bounds.
+- **Unified routing:** Navigate and query the current route via a
+  router-agnostic adapter. Includes `GoRouterAdapter` for `go_router` apps.
+- **Telemetry events:** Broadcasts structured VM service events for window
+  resizes (`ext.slipstream.windowResized`) and route changes
+  (`ext.slipstream.routeChanged`).
 
 ## Getting started
 
-Add `slipstream_agent` as a development dependency:
+Add `slipstream_agent` as a dependency:
+
+```yaml
+dependencies:
+  slipstream_agent: ^0.1.0
+```
+
+Or with the CLI:
 
 ```bash
-flutter pub add dev:slipstream_agent
+flutter pub add slipstream_agent
 ```
 
 ## Usage
 
-Initialize the agent in your `main()` function. The initialization is a no-op
-when the app is not in debug mode (`kDebugMode`).
+Initialize the agent in your `main()` function, guarded by `kDebugMode` so it is
+fully tree-shaken from release builds:
 
 ```dart
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:slipstream_agent/slipstream_agent.dart';
 
 void main() {
-  // Initialize the Slipstream agent.
-  SlipstreamAgent.init();
-
+  if (kDebugMode) {
+    SlipstreamAgent.init();
+  }
   runApp(const MyApp());
 }
 ```
 
-The Slipstream MCP server will automatically detect the presence of the agent
-and use it to provide enhanced capabilities and reliability.
+### With go_router
+
+Pass a `GoRouterAdapter` to enable the `navigate` and `get_route` extensions and
+receive `ext.slipstream.routeChanged` telemetry events:
+
+```dart
+final _router = GoRouter(routes: [...]);
+
+void main() {
+  if (kDebugMode) {
+    SlipstreamAgent.init(router: GoRouterAdapter(_router));
+  }
+  runApp(MyApp(router: _router));
+}
+```
+
+`GoRouterAdapter` does not add a compile-time dependency on `go_router` — it
+accepts the router instance as `dynamic` and accesses it via the `Listenable`
+interface and dynamic method calls.
+
+## Service extensions
+
+All extensions are registered under the `ext.slipstream.*` namespace. See
+[`docs/service_extensions.md`](docs/service_extensions.md) for the full protocol
+reference.
+
+| Extension                         | Description                                              |
+| --------------------------------- | -------------------------------------------------------- |
+| `ext.slipstream.ping`             | Session detection; returns the package version           |
+| `ext.slipstream.perform_action`   | Tap, set_text, scroll, scroll_until_visible              |
+| `ext.slipstream.enable_semantics` | Enables the Flutter semantics tree                       |
+| `ext.slipstream.get_semantics`    | Returns visible semantics nodes with screen-space bounds |
+| `ext.slipstream.navigate`         | Navigates to a route path via the router adapter         |
+| `ext.slipstream.get_route`        | Returns the current route path via the router adapter    |

--- a/slipstream_agent/README.md
+++ b/slipstream_agent/README.md
@@ -1,36 +1,38 @@
 # slipstream_agent
 
-An in-process companion package for the
-[Flutter Slipstream](https://github.com/devoncarew/flutter-slipstream) agent
+A companion package for the
+[Flutter Slipstream](https://github.com/devoncarew/flutter-slipstream) AI agent
 tools.
 
-`package:slipstream_agent` is an optional, opt-in `dev_dependency` that upgrades
-the connection between the Flutter Slipstream MCP server and your running app —
-from external observation to internal cooperation.
+Install this package to give Slipstream deeper access to your running app.
+Without it, Slipstream works through external VM service observation — reliable,
+but limited. With it, the agent can find and interact with any widget in your
+tree, navigate programmatically regardless of which routing library you use, and
+receive real-time telemetry as you build your app.
 
-When the MCP server detects the package (via `ext.slipstream.ping`), it
-automatically routes tool calls through typed in-process extensions instead of
-fragile `evaluate` strings. If the package is not installed, all tools fall back
-silently to the baseline behavior.
+## Why install it
 
-## Features
+- **Find any widget, not just labelled ones.** The baseline tools rely on the
+  Flutter semantics tree, which only knows about widgets with explicit
+  accessibility labels. With this package, the agent can target widgets by
+  `Key`, type, or visible text — no `Semantics` annotations needed.
 
-- **Advanced UI finders:** Target widgets by `Key`, type, or text content
-  without requiring explicit `Semantics` annotations. Supported finders:
-  `byKey`, `byType`, `byText`, `bySemanticsLabel`.
-- **Scroll support:** Programmatically scroll by a fixed amount or scroll until
-  a target widget is visible.
-- **Semantics tree:** Enable the Flutter semantics tree and query visible nodes
-  with accurate screen-space bounds.
-- **Unified routing:** Navigate and query the current route via a
-  router-agnostic adapter. Includes `GoRouterAdapter` for `go_router` apps.
-- **Telemetry events:** Broadcasts structured VM service events for window
-  resizes (`ext.slipstream.windowResized`) and route changes
-  (`ext.slipstream.routeChanged`).
+- **Accurate layout information.** The semantics query extension accumulates
+  transform matrices as it walks the widget tree, so reported bounds are true
+  screen-space coordinates rather than each node's unreliable local coordinate
+  space.
+
+- **Navigate any router.** The baseline `navigate` tool is go_router-specific.
+  With a `RouterAdapter`, navigation and route queries work the same way
+  regardless of which routing library your app uses.
+
+- **Real-time telemetry.** The agent receives structured events as your app runs
+  — window resizes, route changes — without polling.
 
 ## Getting started
 
-Add `slipstream_agent` as a dependency:
+Add `slipstream_agent` as a dependency (the package uses debug-only APIs and is
+fully tree-shaken from release builds):
 
 ```yaml
 dependencies:
@@ -43,14 +45,10 @@ Or with the CLI:
 flutter pub add slipstream_agent
 ```
 
-## Usage
-
-Initialize the agent in your `main()` function, guarded by `kDebugMode` so it is
-fully tree-shaken from release builds:
+Then initialize in `main()`:
 
 ```dart
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:slipstream_agent/slipstream_agent.dart';
 
 void main() {
@@ -63,11 +61,8 @@ void main() {
 
 ### With go_router
 
-Pass a `GoRouterAdapter` to enable the `navigate` and `get_route` extensions and
-receive `ext.slipstream.routeChanged` telemetry events:
-
 ```dart
-final _router = GoRouter(routes: [...]);
+final GoRouter _router = GoRouter(routes: [...]);
 
 void main() {
   if (kDebugMode) {
@@ -77,15 +72,17 @@ void main() {
 }
 ```
 
-`GoRouterAdapter` does not add a compile-time dependency on `go_router` — it
-accepts the router instance as `dynamic` and accesses it via the `Listenable`
-interface and dynamic method calls.
+`GoRouterAdapter` has no compile-time dependency on `go_router` — the router
+instance is accepted as `dynamic`.
 
-## Service extensions
+## How it works
 
-All extensions are registered under the `ext.slipstream.*` namespace. See
-[`docs/service_extensions.md`](docs/service_extensions.md) for the full protocol
-reference.
+When Slipstream connects to your app, it calls `ext.slipstream.ping`. If the
+call succeeds, the server routes tool calls through the typed in-process
+extensions this package registers. If the package is not installed, all tools
+fall back silently to the baseline behavior.
+
+Extensions are registered under the `ext.slipstream.*` namespace:
 
 | Extension                         | Description                                              |
 | --------------------------------- | -------------------------------------------------------- |
@@ -95,3 +92,6 @@ reference.
 | `ext.slipstream.get_semantics`    | Returns visible semantics nodes with screen-space bounds |
 | `ext.slipstream.navigate`         | Navigates to a route path via the router adapter         |
 | `ext.slipstream.get_route`        | Returns the current route path via the router adapter    |
+
+See [`docs/service_extensions.md`](docs/service_extensions.md) for the full
+protocol reference.

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -104,8 +104,6 @@ Failure:
 
 Navigates the app to a route path using the registered router adapter.
 
-> **Status:** implemented.
-
 **Parameters:**
 
 | Name   | Type   | Required | Description                       |
@@ -189,6 +187,7 @@ Failure (semantics not enabled or tree empty):
 
 **Node fields:**
 
+<!-- prettier-ignore-start -->
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `id` | int | Framework-internal node ID; stable until next hot reload/restart |
@@ -206,6 +205,7 @@ Failure (semantics not enabled or tree empty):
 | `top` | double | Screen-space top edge in logical pixels |
 | `right` | double | Screen-space right edge in logical pixels |
 | `bottom` | double | Screen-space bottom edge in logical pixels |
+<!-- prettier-ignore-end -->
 
 Trivial nodes (no role, no actions, no label/value/hint, no relevant state) are
 elided from the list.
@@ -243,12 +243,14 @@ change). Backed by `WidgetsBindingObserver.didChangeMetrics`.
 }
 ```
 
+<!-- prettier-ignore-start -->
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `viewId` | int | Identifies the view that changed (relevant for multi-window apps) |
 | `physicalWidth` / `physicalHeight` | double | Dimensions in physical pixels |
 | `devicePixelRatio` | double | Physical pixels per logical pixel |
 | `logicalWidth` / `logicalHeight` | double | Dimensions in logical pixels (`physical / devicePixelRatio`) |
+<!-- prettier-ignore-end -->
 
 ### `ext.slipstream.routeChanged`
 
@@ -265,6 +267,8 @@ navigation, after the router has settled on the new path.
 { "path": "/podcast/787ae263b723" }
 ```
 
+<!-- prettier-ignore-start -->
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `path` | String | The new current route path, as returned by `RouterAdapter.currentPath()` |
+<!-- prettier-ignore-end -->

--- a/slipstream_agent/example/example.dart
+++ b/slipstream_agent/example/example.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:slipstream_agent/slipstream_agent.dart';
 
 void main() {
-  // Initialize the Slipstream agent.
-  SlipstreamAgent.init();
+  if (kDebugMode) {
+    SlipstreamAgent.init();
+  }
 
   runApp(const SlipstreamExampleApp());
 }

--- a/slipstream_agent/pubspec.yaml
+++ b/slipstream_agent/pubspec.yaml
@@ -1,6 +1,8 @@
 name: slipstream_agent
-description: In-process companion for Slipstream Flutter agent tools.
 version: 0.1.0
+description: An in-process companion for the Flutter Slipstream agent tools.
+
+repository: https://github.com/devoncarew/slipstream_agent/tree/main/slipstream_agent
 
 environment:
   sdk: ^3.3.0

--- a/slipstream_showcase/README.md
+++ b/slipstream_showcase/README.md
@@ -1,7 +1,7 @@
 # slipstream_showcase
 
 A sample Flutter app used for integration testing of the
-[flutter-slipstream](https://github.com/devoncarew/flutter-agent-tools) MCP
+[flutter-slipstream](https://github.com/devoncarew/flutter-slipstream) MCP
 plugin. The app is themed as a "Stellar Catalog" — a lightweight astronomy
 browser — to make it feel like a real application rather than a bare widget
 demo.


### PR DESCRIPTION
Updates all public-facing materials ahead of the first preview release.

- README: rewrites Features to reflect what's actually implemented; adds go_router usage example with `GoRouterAdapter`; adds `kDebugMode` guard to usage sample; adds service extensions table with links to protocol docs
- CHANGELOG: replaces `todo:` placeholder with a full 0.1.0 entry covering all extensions and telemetry events
- example.dart: adds `kDebugMode` guard to match documented best practice
- Minor consistency updates to pubspec.yaml, CLAUDE.md, service_extensions.md, and the showcase README