### PR TITLE
update GoRouterAdapter; rev to 0.1.1

### DIFF
--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+- Update `GoRouterAdapter` to reference the router via the [RouterConfig] parent
+  type for additional type safety.
+
 ## 0.1.0
 
 Initial release.

--- a/slipstream_agent/README.md
+++ b/slipstream_agent/README.md
@@ -10,7 +10,7 @@ but limited. With it, the agent can find and interact with any widget in your
 tree, navigate programmatically regardless of which routing library you use, and
 receive real-time telemetry as you build your app.
 
-## Why install it
+## When used with Flutter Slipstream
 
 - **Find any widget, not just labelled ones.** The baseline tools rely on the
   Flutter semantics tree, which only knows about widgets with explicit

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -9,6 +9,7 @@ import 'finder.dart';
 import 'router_adapter.dart';
 import 'semantics.dart';
 import 'telemetry.dart';
+import 'version.dart';
 
 /// The internal implementation of the Slipstream agent.
 class Agent {
@@ -295,7 +296,7 @@ class Agent {
   Future<Map<String, Object?>> _pingExtension(
       ExtensionParameters parameters) async {
     return {
-      'version': '0.1.0',
+      'version': packageVersion,
     };
   }
 

--- a/slipstream_agent/lib/src/router_adapter.dart
+++ b/slipstream_agent/lib/src/router_adapter.dart
@@ -36,17 +36,17 @@ abstract class RouterAdapter {
 /// SlipstreamAgent.init(router: GoRouterAdapter(_router));
 /// ```
 class GoRouterAdapter extends RouterAdapter {
+  final RouterConfig _router;
+
   /// The [GoRouter] instance. Declared as `dynamic` to avoid a hard
   /// compile-time dependency on the `go_router` package. At runtime, this must
   /// be a `GoRouter` with a `.go(String path)` method and a `.state.uri`
-  /// getter, and it must implement [Listenable].
+  /// getter.
   GoRouterAdapter(this._router) {
-    // GoRouter extends ChangeNotifier, so it is a Listenable. We cast via the
-    // Flutter-provided interface rather than importing go_router.
-    (_router as Listenable).addListener(_onRouteChanged);
+    // We reference via the [RouterConfig] parent type rather than importing
+    // go_router.
+    _router.routeInformationProvider?.addListener(_onRouteChanged);
   }
-
-  final dynamic _router;
 
   void _onRouteChanged() {
     final path = currentPath();
@@ -59,7 +59,7 @@ class GoRouterAdapter extends RouterAdapter {
   void go(BuildContext context, String path) {
     // Calls GoRouter.go(path) dynamically — no import of go_router needed.
     // ignore: avoid_dynamic_calls
-    _router.go(path);
+    (_router as dynamic).go(path);
   }
 
   @override
@@ -67,7 +67,7 @@ class GoRouterAdapter extends RouterAdapter {
     try {
       // Calls GoRouter.state.uri.toString() dynamically.
       // ignore: avoid_dynamic_calls
-      return _router.state.uri.toString();
+      return (_router as dynamic).state.uri.toString();
     } catch (_) {
       return null;
     }

--- a/slipstream_agent/lib/src/version.dart
+++ b/slipstream_agent/lib/src/version.dart
@@ -1,0 +1,4 @@
+// Keep this version in-sync with pubspec.yaml.
+
+/// package:slipstream_agent version.
+const String packageVersion = '0.1.1';

--- a/slipstream_agent/pubspec.yaml
+++ b/slipstream_agent/pubspec.yaml
@@ -1,5 +1,6 @@
 name: slipstream_agent
-version: 0.1.0
+# Keep this version in-sync with lib/src/version.dart.
+version: 0.1.1
 description: An in-process companion for the Flutter Slipstream agent tools.
 
 repository: https://github.com/devoncarew/slipstream_agent/tree/main/slipstream_agent

--- a/slipstream_agent/test/slipstream_agent_test.dart
+++ b/slipstream_agent/test/slipstream_agent_test.dart
@@ -10,9 +10,9 @@ void main() {
 
       SlipstreamAgent.init();
 
-      // We can't easily call the extension directly from the same isolate in a test
-      // without some mocking or using the VM service, but we can verify it doesn't crash
-      // and that the initialization logic is idempotent.
+      // We can't easily call the extension directly from the same isolate in a
+      // test without some mocking or using the VM service, but we can verify it
+      // doesn't crash and that the initialization logic is idempotent.
       SlipstreamAgent.init();
     });
   });


### PR DESCRIPTION
- Update `GoRouterAdapter` to reference the router via the [RouterConfig] parent type for additional type safety.
- rev to 0.1.1
