### PR TITLE
add a ext.slipstream.overlays extension

### DIFF
--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,3 +1,11 @@
+## next
+
+- Add `ext.slipstream.overlays` extension. Calling with `enabled=false` saves
+  the current overlay state and hides all managed overlays (currently the
+  Flutter debug banner via `WidgetsApp.debugAllowBannerOverride`); calling with
+  `enabled=true` restores the previously saved state. Designed for the
+  screenshot use case: hide → capture → restore.
+
 ## 0.1.2
 
 - Fix `GoRouterAdapter` listener registration: cast to `Listenable` (from
@@ -6,8 +14,8 @@
 - Fix `get_semantics` returning an empty node list: revert semantics owner
   lookup to `pipelineOwner.semanticsOwner` (`rootPipelineOwner` was returning
   null).
-- Debounce `ext.slipstream.windowResized` events by 100 ms to avoid
-  flooding clients during continuous window resize.
+- Debounce `ext.slipstream.windowResized` events by 100 ms to avoid flooding
+  clients during continuous window resize.
 - Switch `scrollElement` from `animateTo` to `jumpTo` — animation served no
   purpose for an AI agent caller.
 

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -219,6 +219,49 @@ are true screen-space coordinates.
 
 ---
 
+## `ext.slipstream.overlays`
+
+Shows or hides all Slipstream-managed overlays. Designed for use cases like
+screenshots where overlays should be temporarily hidden.
+
+Calling with `enabled=false` saves the current overlay state internally and
+hides everything. Calling with `enabled=true` restores the previously saved
+state. A frame rebuild is triggered after each change.
+
+**Currently managed overlays:**
+
+| Overlay | Mechanism |
+| ------- | --------- |
+| Flutter debug banner | `WidgetsApp.debugAllowBannerOverride` |
+
+**Parameters:**
+
+| Name      | Type | Required | Description                                              |
+| --------- | ---- | -------- | -------------------------------------------------------- |
+| `enabled` | bool | yes      | `false` to hide all overlays; `true` to restore state    |
+
+**Returns:**
+
+```json
+{ "ok": true }
+```
+
+or
+
+```json
+{ "ok": false, "error": "overlays: \"enabled\" parameter is required" }
+```
+
+**Typical screenshot flow:**
+
+```
+1. call ext.slipstream.overlays(enabled: false)
+2. take screenshot
+3. call ext.slipstream.overlays(enabled: true)
+```
+
+---
+
 ## Events
 
 Events are posted to the VM service `Extension` stream via

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -89,7 +89,7 @@ Failure:
 
 - **scroll** — finds a `Scrollable` in the element's subtree and calls
   `position.animateTo(pixels + delta)`. Required params: `direction` (`"up"`,
-  `"down"`, `"left"`, `"right"`) and `pixels` (logical pixels as a string).
+  `"down"`, `"left"`, `"right"`) and `pixels` (logical pixels as a double).
   Clamped to the scroll extent bounds.
 
 - **scroll_until_visible** — scrolls the `Scrollable` identified by
@@ -230,15 +230,15 @@ state. A frame rebuild is triggered after each change.
 
 **Currently managed overlays:**
 
-| Overlay | Mechanism |
-| ------- | --------- |
+| Overlay              | Mechanism                             |
+| -------------------- | ------------------------------------- |
 | Flutter debug banner | `WidgetsApp.debugAllowBannerOverride` |
 
 **Parameters:**
 
-| Name      | Type | Required | Description                                              |
-| --------- | ---- | -------- | -------------------------------------------------------- |
-| `enabled` | bool | yes      | `false` to hide all overlays; `true` to restore state    |
+| Name      | Type | Required | Description                                           |
+| --------- | ---- | -------- | ----------------------------------------------------- |
+| `enabled` | bool | yes      | `false` to hide all overlays; `true` to restore state |
 
 **Returns:**
 

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -6,6 +6,7 @@ import 'package:service_extensions/service_extensions.dart';
 
 import 'actions.dart';
 import 'finder.dart';
+import 'overlays.dart';
 import 'router_adapter.dart';
 import 'semantics.dart';
 import 'telemetry.dart';
@@ -60,6 +61,11 @@ class Agent {
     registerServiceExtension(
       _getSemanticsDescription,
       _getSemanticsExtension,
+    );
+
+    registerServiceExtension(
+      _overlaysDescription,
+      _overlaysExtension,
     );
 
     initTelemetry();
@@ -348,5 +354,54 @@ class Agent {
     final (nodes, error) = getSemanticsNodes();
     if (error != null) return {'ok': false, 'error': error};
     return {'ok': true, 'nodes': nodes};
+  }
+
+  final ServiceDescription _overlaysDescription = ServiceDescription(
+    name: 'ext.slipstream.overlays',
+    description:
+        'Shows or hides all Slipstream-managed overlays (debug banner, and '
+        'future Slipstream overlays). Passing enabled=false saves the current '
+        'overlay state and hides everything; passing enabled=true restores the '
+        'previously saved state. Triggers a frame rebuild after each change.',
+    parameters: [
+      ParameterDescription(
+        name: 'enabled',
+        type: 'bool',
+        description:
+            'false to hide all overlays (saving state); true to restore.',
+        required: true,
+      ),
+    ],
+    returns: [
+      ReturnDescription(
+          name: 'ok', type: 'bool', description: 'The status of the call.'),
+      ReturnDescription(
+          name: 'error',
+          type: 'String',
+          description: 'A message describing any error.'),
+    ],
+  );
+
+  Future<Map<String, Object?>> _overlaysExtension(
+      ExtensionParameters parameters) async {
+    final String? enabledStr = parameters.asString('enabled');
+    if (enabledStr == null) {
+      return {'ok': false, 'error': 'overlays: "enabled" parameter is required'};
+    }
+    final bool? enabled = enabledStr == 'true'
+        ? true
+        : enabledStr == 'false'
+            ? false
+            : null;
+    if (enabled == null) {
+      return {
+        'ok': false,
+        'error': 'overlays: "enabled" must be "true" or "false", '
+            'got "$enabledStr"',
+      };
+    }
+
+    setOverlaysEnabled(enabled);
+    return {'ok': true};
   }
 }

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -108,7 +108,7 @@ class Agent {
       ),
       ParameterDescription(
         name: 'pixels',
-        type: 'String',
+        type: 'double',
         description: 'Required for scroll: number of logical pixels.',
       ),
       ParameterDescription(
@@ -142,7 +142,7 @@ class Agent {
     final String finderValue = parameters.asStringRequired('finderValue');
     final String? text = parameters.asString('text');
     final String? direction = parameters.asString('direction');
-    final String? pixelsStr = parameters.asString('pixels');
+    final double? pixels = parameters.asDouble('pixels');
     final String? scrollFinder = parameters.asString('scrollFinder');
     final String? scrollFinderValue = parameters.asString('scrollFinderValue');
 
@@ -168,19 +168,14 @@ class Agent {
       case 'scroll':
         if (direction == null) {
           error = 'interact: "direction" is required for the scroll action';
-        } else if (pixelsStr == null) {
+        } else if (pixels == null) {
           error = 'interact: "pixels" is required for the scroll action';
         } else {
-          final double? pixels = double.tryParse(pixelsStr);
-          if (pixels == null) {
-            error = 'interact: "pixels" must be a number, got "$pixelsStr"';
-          } else {
-            error = await scrollElement(
-              element,
-              direction: direction,
-              pixels: pixels,
-            );
-          }
+          error = await scrollElement(
+            element,
+            direction: direction,
+            pixels: pixels,
+          );
         }
       case 'scroll_until_visible':
         if (scrollFinder == null || scrollFinderValue == null) {
@@ -380,25 +375,7 @@ class Agent {
 
   Future<Map<String, Object?>> _overlaysExtension(
       ExtensionParameters parameters) async {
-    final String? enabledStr = parameters.asString('enabled');
-    if (enabledStr == null) {
-      return {
-        'ok': false,
-        'error': 'overlays: "enabled" parameter is required'
-      };
-    }
-    final bool? enabled = enabledStr == 'true'
-        ? true
-        : enabledStr == 'false'
-            ? false
-            : null;
-    if (enabled == null) {
-      return {
-        'ok': false,
-        'error': 'overlays: "enabled" must be "true" or "false", '
-            'got "$enabledStr"',
-      };
-    }
+    final enabled = parameters.asBoolRequired('enabled');
 
     setOverlaysEnabled(enabled);
 

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -315,11 +315,7 @@ class Agent {
   Future<Map<String, Object?>> _enableSemanticsExtension(
       ExtensionParameters parameters) async {
     RendererBinding.instance.ensureSemantics();
-    final completer = Completer();
-    WidgetsBinding.instance.scheduleFrameCallback(
-        (timeStamp) => completer.complete(),
-        scheduleNewFrame: true);
-    await completer.future;
+    await _waitForNextFrame();
     return {};
   }
 
@@ -386,7 +382,10 @@ class Agent {
       ExtensionParameters parameters) async {
     final String? enabledStr = parameters.asString('enabled');
     if (enabledStr == null) {
-      return {'ok': false, 'error': 'overlays: "enabled" parameter is required'};
+      return {
+        'ok': false,
+        'error': 'overlays: "enabled" parameter is required'
+      };
     }
     final bool? enabled = enabledStr == 'true'
         ? true
@@ -402,6 +401,18 @@ class Agent {
     }
 
     setOverlaysEnabled(enabled);
+
+    await _waitForNextFrame();
+
     return {'ok': true};
+  }
+
+  // A addPostFrameCallback() callback may be more correct here.
+  Future<void> _waitForNextFrame() async {
+    final completer = Completer();
+    WidgetsBinding.instance.scheduleFrameCallback(
+        (timeStamp) => completer.complete(),
+        scheduleNewFrame: true);
+    await completer.future;
   }
 }

--- a/slipstream_agent/lib/src/overlays.dart
+++ b/slipstream_agent/lib/src/overlays.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/widgets.dart';
+
+/// Manages visibility of Flutter and Slipstream overlays.
+///
+/// Call with `false` to hide all overlays and save their current state.
+/// Call with `true` to restore the previously saved state. If called with
+/// `true` before any `false` call, it is a no-op.
+///
+/// Marks the widget tree dirty and schedules a frame, but does not await the
+/// frame. Callers that need the change to be painted before proceeding (e.g.
+/// before taking a screenshot) should wait for the next frame themselves.
+void setOverlaysEnabled(bool enabled) {
+  if (enabled) {
+    _restore();
+  } else {
+    _save();
+    _hideAll();
+  }
+
+  // Mark the tree dirty so the overlay change takes effect on the next frame.
+  final root = WidgetsBinding.instance.rootElement;
+  if (root != null) {
+    _markNeedsRebuild(root);
+  }
+  WidgetsBinding.instance.scheduleFrame();
+}
+
+// ---------------------------------------------------------------------------
+// Saved state
+
+bool? _savedDebugBanner;
+
+void _save() {
+  _savedDebugBanner = WidgetsApp.debugAllowBannerOverride;
+}
+
+void _hideAll() {
+  WidgetsApp.debugAllowBannerOverride = false;
+}
+
+void _restore() {
+  if (_savedDebugBanner != null) {
+    WidgetsApp.debugAllowBannerOverride = _savedDebugBanner!;
+    _savedDebugBanner = null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+
+/// Marks every element in the tree dirty so Flutter rebuilds after the overlay
+/// state change.
+void _markNeedsRebuild(Element element) {
+  element.markNeedsBuild();
+  element.visitChildren(_markNeedsRebuild);
+}

--- a/slipstream_agent/test/slipstream_agent_test.dart
+++ b/slipstream_agent/test/slipstream_agent_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:slipstream_agent/slipstream_agent.dart';
 import 'package:slipstream_agent/src/actions.dart';
 import 'package:slipstream_agent/src/finder.dart';
+import 'package:slipstream_agent/src/overlays.dart';
 import 'package:slipstream_agent/src/semantics.dart';
 
 void main() {
@@ -481,6 +482,62 @@ void main() {
 
       expect(right - left, greaterThan(0));
       expect(bottom - top, greaterThan(0));
+    });
+  });
+
+  group('setOverlaysEnabled', () {
+    setUp(() {
+      // Ensure the banner override is in its default state before each test.
+      WidgetsApp.debugAllowBannerOverride = true;
+    });
+
+    testWidgets('hides the debug banner when called with false', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+
+      expect(WidgetsApp.debugAllowBannerOverride, isTrue);
+
+      setOverlaysEnabled(false);
+      await tester.pump();
+
+      expect(WidgetsApp.debugAllowBannerOverride, isFalse);
+    });
+
+    testWidgets('restores the debug banner when called with true',
+        (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+
+      setOverlaysEnabled(false);
+      await tester.pump();
+      expect(WidgetsApp.debugAllowBannerOverride, isFalse);
+
+      setOverlaysEnabled(true);
+      await tester.pump();
+      expect(WidgetsApp.debugAllowBannerOverride, isTrue);
+    });
+
+    testWidgets('restores to false if banner was already hidden', (tester) async {
+      WidgetsApp.debugAllowBannerOverride = false;
+      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+
+      setOverlaysEnabled(false);
+      await tester.pump();
+
+      setOverlaysEnabled(true);
+      await tester.pump();
+
+      // Restored to the state it was in before the hide call.
+      expect(WidgetsApp.debugAllowBannerOverride, isFalse);
+    });
+
+    testWidgets('restore is a no-op when no prior hide was called',
+        (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+
+      // No hide call made — restore should leave the banner enabled.
+      setOverlaysEnabled(true);
+      await tester.pump();
+
+      expect(WidgetsApp.debugAllowBannerOverride, isTrue);
     });
   });
 }

--- a/slipstream_agent/test/slipstream_agent_test.dart
+++ b/slipstream_agent/test/slipstream_agent_test.dart
@@ -491,7 +491,8 @@ void main() {
       WidgetsApp.debugAllowBannerOverride = true;
     });
 
-    testWidgets('hides the debug banner when called with false', (tester) async {
+    testWidgets('hides the debug banner when called with false',
+        (tester) async {
       await tester.pumpWidget(const MaterialApp(home: Scaffold()));
 
       expect(WidgetsApp.debugAllowBannerOverride, isTrue);
@@ -515,7 +516,8 @@ void main() {
       expect(WidgetsApp.debugAllowBannerOverride, isTrue);
     });
 
-    testWidgets('restores to false if banner was already hidden', (tester) async {
+    testWidgets('restores to false if banner was already hidden',
+        (tester) async {
       WidgetsApp.debugAllowBannerOverride = false;
       await tester.pumpWidget(const MaterialApp(home: Scaffold()));
 

--- a/slipstream_showcase/.gitignore
+++ b/slipstream_showcase/.gitignore
@@ -28,3 +28,5 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+.gemini/


### PR DESCRIPTION
Add an ext.slipstream.overlays extension:

- Add `ext.slipstream.overlays` extension. Calling with `enabled=false` saves the current overlay state and hides all managed overlays (currently the Flutter debug banner via `WidgetsApp.debugAllowBannerOverride`); calling with `enabled=true` restores the previously saved state. Designed for the screenshot use case: hide → capture → restore.
- fix the types of some ext. method paameters
