### PR TITLE
Add ghost overlay and release 1.1.0

### DIFF
--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,16 +1,31 @@
-## 1.1.0-wip
+## 1.1.0
 
 - Add `ext.slipstream.log` extension and ghost overlay command log. A
-  translucent chip stack appears in the bottom-right corner of the app showing
-  recent agent actions (e.g. "tap: login_button", "navigate: /home"). In-process
-  extensions log automatically; the MCP server calls `ext.slipstream.log` for
-  out-of-process operations (reload, screenshot, evaluate, etc.). Each chip is
-  shown for 3 seconds then removed.
+  translucent chip appears at the bottom of the app showing the most recent
+  agent action (e.g. "tap: login_button", "navigate: /home"), then slides out
+  after 3 seconds. In-process extensions log automatically; the MCP server calls
+  `ext.slipstream.log` for out-of-process operations (reload, screenshot,
+  evaluate, etc.).
 - Ghost overlay now installs on the first `ext.slipstream.ping` (or any log
   call), permanently replacing the Flutter debug banner with a "slipstream"
-  banner in the top-right corner. `ext.slipstream.overlays` now only toggles
-  the ghost overlay visibility (banner + chips) and no longer saves/restores
+  banner in the top-right corner. `ext.slipstream.overlays` now only toggles the
+  ghost overlay visibility (banner + chips) and no longer saves/restores
   `WidgetsApp.debugAllowBannerOverride`.
+- `ext.slipstream.log` accepts `kind`, `finder`, `finderValue`, and `viz`
+  parameters for richer visualizations. `kind` controls the icon shown in the
+  chip (`"read"`, `"interact"`, `"reload"`, `"screenshot"`). `viz` triggers an
+  extra visual effect: `"flash"` (brief full-screen tint), `"outline"` (animated
+  bounding-box highlight on the target widget), `"semantics"` (bounding-box
+  outlines on all visible semantics nodes), or `"layout"` (falls back to
+  `"outline"` for now).
+- Fix `ext.slipstream.get_semantics` returning incorrect screen-space
+  coordinates. The previous implementation accumulated `SemanticsNode.transform`
+  values, which are in physical pixels (scaled by `devicePixelRatio`). The new
+  implementation walks the render tree using `RenderBox.localToGlobal`, which
+  stays in logical pixels and matches the overlay coordinate system.
+  `visitChildrenForSemantics` is used instead of `visitChildren` so that render
+  objects excluded from semantics (e.g. inactive `IndexedStack` tabs) are not
+  collected.
 
 ## 1.0.0
 

--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,11 +1,14 @@
-## 1.0.0
+## 1.1.0-wip
 
 - Add `ext.slipstream.log` extension and ghost overlay command log. A
-  translucent chip stack appears in the bottom-right corner of the app
-  showing recent agent actions (e.g. "tap: login_button", "navigate:
-  /home"). In-process extensions log automatically; the MCP server calls
-  `ext.slipstream.log` for out-of-process operations (reload, screenshot,
-  evaluate, etc.). Each chip is shown for 3 seconds then removed.
+  translucent chip stack appears in the bottom-right corner of the app showing
+  recent agent actions (e.g. "tap: login_button", "navigate: /home"). In-process
+  extensions log automatically; the MCP server calls `ext.slipstream.log` for
+  out-of-process operations (reload, screenshot, evaluate, etc.). Each chip is
+  shown for 3 seconds then removed.
+
+## 1.0.0
+
 - Add `ext.slipstream.overlays` extension. Calling with `enabled=false` saves
   the current overlay state and hides all managed overlays (currently the
   Flutter debug banner via `WidgetsApp.debugAllowBannerOverride`); calling with

--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 1.0.0
 
+- Add `ext.slipstream.log` extension and ghost overlay command log. A
+  translucent chip stack appears in the bottom-right corner of the app
+  showing recent agent actions (e.g. "tap: login_button", "navigate:
+  /home"). In-process extensions log automatically; the MCP server calls
+  `ext.slipstream.log` for out-of-process operations (reload, screenshot,
+  evaluate, etc.). Each chip is shown for 3 seconds then removed.
 - Add `ext.slipstream.overlays` extension. Calling with `enabled=false` saves
   the current overlay state and hides all managed overlays (currently the
   Flutter debug banner via `WidgetsApp.debugAllowBannerOverride`); calling with

--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -6,6 +6,11 @@
   extensions log automatically; the MCP server calls `ext.slipstream.log` for
   out-of-process operations (reload, screenshot, evaluate, etc.). Each chip is
   shown for 3 seconds then removed.
+- Ghost overlay now installs on the first `ext.slipstream.ping` (or any log
+  call), permanently replacing the Flutter debug banner with a "slipstream"
+  banner in the top-right corner. `ext.slipstream.overlays` now only toggles
+  the ghost overlay visibility (banner + chips) and no longer saves/restores
+  `WidgetsApp.debugAllowBannerOverride`.
 
 ## 1.0.0
 

--- a/slipstream_agent/docs/notes.md
+++ b/slipstream_agent/docs/notes.md
@@ -1,13 +1,5 @@
 ## Ghost Overlay
 
-- Widget highlight on tap
-- Widget highlight on set_text
-- Semantics bounding box flash on get_semantics
-- Widget highlight on inspect layout
-- Overlay display on reload
-- Overlay display on run app?
-- Overlay display on evaluate
-
 Visualizations:
 
 | Command                        | Description (icon) "log message" visualization         |

--- a/slipstream_agent/docs/notes.md
+++ b/slipstream_agent/docs/notes.md
@@ -1,0 +1,28 @@
+## Ghost Overlay
+
+- Widget highlight on tap
+- Widget highlight on set_text
+- Semantics bounding box flash on get_semantics
+- Widget highlight on inspect layout
+- Overlay display on reload
+- Overlay display on run app?
+- Overlay display on evaluate
+
+Visualizations:
+
+| Command                        | Description (icon) "log message" visualization         |
+| ------------------------------ | ------------------------------------------------------ |
+| `run_app`                      | -                                                      |
+| `reload`                       | (refresh) "reload: 300ms"                              |
+| `take_screenshot`              | (camera) "screenshot" flash screen                     |
+| `inspect_layout`               | (read) "inspect layout" inspect bounding box           |
+| `evaluate`                     | (read) "evaluate: 'expr'"                              |
+| `get_route`                    | (read) "get route"                                     |
+| `navigate`                     | (interact) "navigate: route"                           |
+| `perform_tap`                  | (interact) "tap: id" bounding box                      |
+| `perform_set_text`             | (interact) "set text: id 'text'" bounding box          |
+| `perform_scroll`               | (interact) "scroll: id" bounding box?                  |
+| `perform_scroll_until_visible` | (interact) "scroll until visible: id" bounding box?    |
+| `get_semantics`                | (read) "get semantics" semantics bounding boxes        |
+| `perform_semantic_action`      | (interact) "perform semantic: action id" bounding box? |
+| `close_app`                    | -                                                      |

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -271,34 +271,35 @@ extension (e.g. hot reload, screenshot, evaluate). In-process extensions
 
 **Parameters:**
 
-| Name          | Type   | Required | Description                                                                       |
-| ------------- | ------ | -------- | --------------------------------------------------------------------------------- |
-| `command`     | String | yes      | Short label: `"reload"`, `"screenshot"`, `"evaluate"`, etc.                       |
-| `details`     | String | no       | Optional detail appended after a colon: a path, text value, etc.                  |
-| `kind`        | String | no       | Icon category: `"peek"`, `"poke"`, `"reload"`, or `"screenshot"`                  |
+| Name          | Type   | Required | Description                                                                                     |
+| ------------- | ------ | -------- | ----------------------------------------------------------------------------------------------- |
+| `command`     | String | yes      | Short label: `"reload"`, `"screenshot"`, `"evaluate"`, etc.                                     |
+| `details`     | String | no       | Optional detail appended after a colon: a path, text value, etc.                                |
+| `kind`        | String | no       | Icon category: `"read"`, `"interact"`, `"reload"`, or `"screenshot"`                            |
 | `finder`      | String | no       | Finder type for the widget of interest: `"byKey"`, `"byType"`, `"byText"`, `"bySemanticsLabel"` |
-| `finderValue` | String | no       | Value to match against the chosen finder                                           |
-| `viz`         | String | no       | Extra visualization: `"flash"`, `"outline"`, `"layout"`, or `"semantics"`         |
+| `finderValue` | String | no       | Value to match against the chosen finder                                                        |
+| `viz`         | String | no       | Extra visualization: `"flash"`, `"outline"`, `"layout"`, or `"semantics"`                       |
 
 **`kind` values:**
 
-| Value          | Icon hint   | Typical commands                                        |
-| -------------- | ----------- | ------------------------------------------------------- |
-| `"reload"`     | refresh     | `reload`                                                |
-| `"screenshot"` | camera      | `take_screenshot`                                       |
-| `"peek"`       | eye/data    | `evaluate`, `get_route`, `get_semantics`, `inspect_layout` |
-| `"poke"`       | cursor/touch | `navigate`, `tap`, `set_text`, `scroll`                |
+| Value          | Icon hint    | Typical commands                                           |
+| -------------- | ------------ | ---------------------------------------------------------- |
+| `"reload"`     | refresh      | `reload`                                                   |
+| `"screenshot"` | camera       | `take_screenshot`                                          |
+| `"read"`       | eye/data     | `evaluate`, `get_route`, `get_semantics`, `inspect_layout` |
+| `"interact"`   | cursor/touch | `navigate`, `tap`, `set_text`, `scroll`                    |
 
 **`viz` values:**
 
-| Value         | Effect                                                       | Typical pairing              |
-| ------------- | ------------------------------------------------------------ | ---------------------------- |
-| `"flash"`     | Brief full-screen tint                                       | `take_screenshot`            |
-| `"outline"`   | Bounding-box highlight on the `finder`/`finderValue` widget  | `tap`, `set_text`, `scroll`  |
-| `"layout"`    | Bounding box with layout annotations (padding, flex arrows)  | `inspect_layout`             |
-| `"semantics"` | Flash outlines on all visible semantics nodes                | `get_semantics`              |
+| Value         | Effect                                                      | Typical pairing             |
+| ------------- | ----------------------------------------------------------- | --------------------------- |
+| `"flash"`     | Brief full-screen tint                                      | `take_screenshot`           |
+| `"outline"`   | Bounding-box highlight on the `finder`/`finderValue` widget | `tap`, `set_text`, `scroll` |
+| `"layout"`    | Bounding box with layout annotations (padding, flex arrows) | `inspect_layout`            |
+| `"semantics"` | Flash outlines on all visible semantics nodes               | `get_semantics`             |
 
-`viz: "outline"` and `viz: "layout"` require `finder` + `finderValue`; silently ignored if omitted.
+`viz: "outline"` and `viz: "layout"` require `finder` + `finderValue`; silently
+ignored if omitted.
 
 **Display format:** `command` when no details; `command: details` otherwise.
 
@@ -310,14 +311,14 @@ extension (e.g. hot reload, screenshot, evaluate). In-process extensions
 
 **Examples of MCP server usage:**
 
-| MCP tool          | Suggested call                                                                         |
-| ----------------- | -------------------------------------------------------------------------------------- |
-| `reload`          | `log(command: "reload", details: "300ms", kind: "reload")`                             |
-| `take_screenshot` | `log(command: "screenshot", kind: "screenshot", viz: "flash")`                         |
-| `evaluate`        | `log(command: "evaluate", details: "widget.toString()", kind: "peek")`                 |
-| `inspect_layout`  | `log(command: "inspect layout", kind: "peek", finder: "byKey", finderValue: "my_widget", viz: "layout")` |
-| `navigate`        | logged automatically by `ext.slipstream.navigate`                                      |
-| `perform_tap`     | logged automatically by `ext.slipstream.perform_action`                                |
+| MCP tool          | Suggested call                                                                                           |
+| ----------------- | -------------------------------------------------------------------------------------------------------- |
+| `reload`          | `log(command: "reload", details: "300ms", kind: "reload")`                                               |
+| `take_screenshot` | `log(command: "screenshot", kind: "screenshot", viz: "flash")`                                           |
+| `evaluate`        | `log(command: "evaluate", details: "widget.toString()", kind: "read")`                                   |
+| `inspect_layout`  | `log(command: "inspect layout", kind: "read", finder: "byKey", finderValue: "my_widget", viz: "layout")` |
+| `navigate`        | logged automatically by `ext.slipstream.navigate`                                                        |
+| `perform_tap`     | logged automatically by `ext.slipstream.perform_action`                                                  |
 
 ---
 

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -219,7 +219,7 @@ are true screen-space coordinates.
 
 ---
 
-## `ext.slipstream.overlays` (added in v1.0.0)
+## `ext.slipstream.overlays` (since v1.0.0)
 
 Shows or hides all Slipstream-managed overlays. Designed for use cases like
 screenshots where overlays should be temporarily hidden.
@@ -262,7 +262,7 @@ or
 
 ---
 
-## `ext.slipstream.log` (added in v1.1.0)
+## `ext.slipstream.log` (since v1.1.0)
 
 Logs an agent command to the ghost overlay command log. The Slipstream MCP
 server calls this for operations that do not flow through an in-process

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -262,6 +262,40 @@ or
 
 ---
 
+## `ext.slipstream.log`
+
+Logs an agent command to the ghost overlay command log. The Slipstream MCP
+server calls this for operations that do not flow through an in-process
+extension (e.g. hot reload, screenshot, evaluate). In-process extensions
+(`perform_action`, `navigate`, etc.) log automatically.
+
+**Parameters:**
+
+| Name      | Type   | Required | Description                                                      |
+| --------- | ------ | -------- | ---------------------------------------------------------------- |
+| `command` | String | yes      | Short label: `"reload"`, `"screenshot"`, `"evaluate"`, etc.      |
+| `details` | String | no       | Optional detail appended after a colon: a path, text value, etc. |
+
+**Display format:** `command` when no details; `command: details` otherwise.
+
+**Returns:**
+
+```json
+{ "ok": true }
+```
+
+**Examples of MCP server usage:**
+
+| MCP tool          | Suggested call                                           |
+| ----------------- | -------------------------------------------------------- |
+| `reload`          | `log(command: "reload", details: "300ms")`               |
+| `take_screenshot` | `log(command: "screenshot")`                             |
+| `evaluate`        | `log(command: "evaluate", details: "widget.toString()")` |
+| `navigate`        | logged automatically by `ext.slipstream.navigate`        |
+| `perform_tap`     | logged automatically by `ext.slipstream.perform_action`  |
+
+---
+
 ## Events
 
 Events are posted to the VM service `Extension` stream via

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -219,7 +219,7 @@ are true screen-space coordinates.
 
 ---
 
-## `ext.slipstream.overlays`
+## `ext.slipstream.overlays` (added in v1.0.0)
 
 Shows or hides all Slipstream-managed overlays. Designed for use cases like
 screenshots where overlays should be temporarily hidden.
@@ -262,7 +262,7 @@ or
 
 ---
 
-## `ext.slipstream.log`
+## `ext.slipstream.log` (added in v1.1.0)
 
 Logs an agent command to the ghost overlay command log. The Slipstream MCP
 server calls this for operations that do not flow through an in-process
@@ -271,10 +271,34 @@ extension (e.g. hot reload, screenshot, evaluate). In-process extensions
 
 **Parameters:**
 
-| Name      | Type   | Required | Description                                                      |
-| --------- | ------ | -------- | ---------------------------------------------------------------- |
-| `command` | String | yes      | Short label: `"reload"`, `"screenshot"`, `"evaluate"`, etc.      |
-| `details` | String | no       | Optional detail appended after a colon: a path, text value, etc. |
+| Name          | Type   | Required | Description                                                                       |
+| ------------- | ------ | -------- | --------------------------------------------------------------------------------- |
+| `command`     | String | yes      | Short label: `"reload"`, `"screenshot"`, `"evaluate"`, etc.                       |
+| `details`     | String | no       | Optional detail appended after a colon: a path, text value, etc.                  |
+| `kind`        | String | no       | Icon category: `"peek"`, `"poke"`, `"reload"`, or `"screenshot"`                  |
+| `finder`      | String | no       | Finder type for the widget of interest: `"byKey"`, `"byType"`, `"byText"`, `"bySemanticsLabel"` |
+| `finderValue` | String | no       | Value to match against the chosen finder                                           |
+| `viz`         | String | no       | Extra visualization: `"flash"`, `"outline"`, `"layout"`, or `"semantics"`         |
+
+**`kind` values:**
+
+| Value          | Icon hint   | Typical commands                                        |
+| -------------- | ----------- | ------------------------------------------------------- |
+| `"reload"`     | refresh     | `reload`                                                |
+| `"screenshot"` | camera      | `take_screenshot`                                       |
+| `"peek"`       | eye/data    | `evaluate`, `get_route`, `get_semantics`, `inspect_layout` |
+| `"poke"`       | cursor/touch | `navigate`, `tap`, `set_text`, `scroll`                |
+
+**`viz` values:**
+
+| Value         | Effect                                                       | Typical pairing              |
+| ------------- | ------------------------------------------------------------ | ---------------------------- |
+| `"flash"`     | Brief full-screen tint                                       | `take_screenshot`            |
+| `"outline"`   | Bounding-box highlight on the `finder`/`finderValue` widget  | `tap`, `set_text`, `scroll`  |
+| `"layout"`    | Bounding box with layout annotations (padding, flex arrows)  | `inspect_layout`             |
+| `"semantics"` | Flash outlines on all visible semantics nodes                | `get_semantics`              |
+
+`viz: "outline"` and `viz: "layout"` require `finder` + `finderValue`; silently ignored if omitted.
 
 **Display format:** `command` when no details; `command: details` otherwise.
 
@@ -286,13 +310,14 @@ extension (e.g. hot reload, screenshot, evaluate). In-process extensions
 
 **Examples of MCP server usage:**
 
-| MCP tool          | Suggested call                                           |
-| ----------------- | -------------------------------------------------------- |
-| `reload`          | `log(command: "reload", details: "300ms")`               |
-| `take_screenshot` | `log(command: "screenshot")`                             |
-| `evaluate`        | `log(command: "evaluate", details: "widget.toString()")` |
-| `navigate`        | logged automatically by `ext.slipstream.navigate`        |
-| `perform_tap`     | logged automatically by `ext.slipstream.perform_action`  |
+| MCP tool          | Suggested call                                                                         |
+| ----------------- | -------------------------------------------------------------------------------------- |
+| `reload`          | `log(command: "reload", details: "300ms", kind: "reload")`                             |
+| `take_screenshot` | `log(command: "screenshot", kind: "screenshot", viz: "flash")`                         |
+| `evaluate`        | `log(command: "evaluate", details: "widget.toString()", kind: "peek")`                 |
+| `inspect_layout`  | `log(command: "inspect layout", kind: "peek", finder: "byKey", finderValue: "my_widget", viz: "layout")` |
+| `navigate`        | logged automatically by `ext.slipstream.navigate`                                      |
+| `perform_tap`     | logged automatically by `ext.slipstream.perform_action`                                |
 
 ---
 

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -166,7 +166,7 @@ class Agent {
       case 'tap':
         GhostOverlay.log('tap',
             details: finderValue,
-            kind: 'poke',
+            kind: 'interact',
             finder: finder,
             finderValue: finderValue,
             viz: 'outline');
@@ -177,7 +177,7 @@ class Agent {
         } else {
           GhostOverlay.log('set text',
               details: '"$text"',
-              kind: 'poke',
+              kind: 'interact',
               finder: finder,
               finderValue: finderValue,
               viz: 'outline');
@@ -191,7 +191,7 @@ class Agent {
         } else {
           GhostOverlay.log('scroll',
               details: '$direction ${pixels}px',
-              kind: 'poke',
+              kind: 'interact',
               finder: finder,
               finderValue: finderValue,
               viz: 'outline');
@@ -218,7 +218,7 @@ class Agent {
           } else {
             GhostOverlay.log('scroll to',
                 details: finderValue,
-                kind: 'poke',
+                kind: 'interact',
                 finder: finder,
                 finderValue: finderValue,
                 viz: 'outline');
@@ -252,7 +252,7 @@ class Agent {
 
   Future<Map<String, Object?>> _getRouteExtension(
       ExtensionParameters parameters) async {
-    GhostOverlay.log('get route', kind: 'peek');
+    GhostOverlay.log('get route', kind: 'read');
     final path = _router?.currentPath();
     if (path == null) {
       return {
@@ -307,7 +307,7 @@ class Agent {
     }
 
     try {
-      GhostOverlay.log('navigate', details: path, kind: 'poke');
+      GhostOverlay.log('navigate', details: path, kind: 'interact');
       _router!.go(root, path);
       return {'ok': true};
     } catch (e) {
@@ -342,7 +342,7 @@ class Agent {
 
   Future<Map<String, Object?>> _enableSemanticsExtension(
       ExtensionParameters parameters) async {
-    GhostOverlay.log('enable semantics', kind: 'peek');
+    GhostOverlay.log('enable semantics', kind: 'read');
     RendererBinding.instance.ensureSemantics();
     await _waitForNextFrame();
     return {};
@@ -376,7 +376,7 @@ class Agent {
 
   Future<Map<String, Object?>> _getSemanticsExtension(
       ExtensionParameters parameters) async {
-    GhostOverlay.log('get semantics', kind: 'peek', viz: 'semantics');
+    GhostOverlay.log('get semantics', kind: 'read', viz: 'semantics');
     final (nodes, error) = getSemanticsNodes();
     if (error != null) return {'ok': false, 'error': error};
     return {'ok': true, 'nodes': nodes};
@@ -445,7 +445,7 @@ class Agent {
       ParameterDescription(
         name: 'kind',
         type: 'String',
-        description: 'Icon category hint: "peek", "poke", "reload", or '
+        description: 'Icon category hint: "read", "interact", "reload", or '
             '"screenshot".',
       ),
       ParameterDescription(

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -164,13 +164,23 @@ class Agent {
     String? error;
     switch (action) {
       case 'tap':
-        GhostOverlay.log('tap', details: finderValue);
+        GhostOverlay.log('tap',
+            details: finderValue,
+            kind: 'poke',
+            finder: finder,
+            finderValue: finderValue,
+            viz: 'outline');
         error = await tapElement(element);
       case 'set_text':
         if (text == null) {
           error = 'interact: "text" is required for the set_text action';
         } else {
-          GhostOverlay.log('set text', details: '"$text"');
+          GhostOverlay.log('set text',
+              details: '"$text"',
+              kind: 'poke',
+              finder: finder,
+              finderValue: finderValue,
+              viz: 'outline');
           error = setTextInElement(element, text);
         }
       case 'scroll':
@@ -179,7 +189,12 @@ class Agent {
         } else if (pixels == null) {
           error = 'interact: "pixels" is required for the scroll action';
         } else {
-          GhostOverlay.log('scroll', details: '$direction ${pixels}px');
+          GhostOverlay.log('scroll',
+              details: '$direction ${pixels}px',
+              kind: 'poke',
+              finder: finder,
+              finderValue: finderValue,
+              viz: 'outline');
           error = await scrollElement(
             element,
             direction: direction,
@@ -201,7 +216,12 @@ class Agent {
                 'interact: no scrollable found for scrollFinder="$scrollFinder"'
                 ' value="$scrollFinderValue"';
           } else {
-            GhostOverlay.log('scroll to', details: scrollFinderValue);
+            GhostOverlay.log('scroll to',
+                details: finderValue,
+                kind: 'poke',
+                finder: finder,
+                finderValue: finderValue,
+                viz: 'outline');
             error = await scrollUntilVisible(
               targetElement: element,
               scrollableElement: scrollable,
@@ -232,7 +252,7 @@ class Agent {
 
   Future<Map<String, Object?>> _getRouteExtension(
       ExtensionParameters parameters) async {
-    GhostOverlay.log('get route');
+    GhostOverlay.log('get route', kind: 'peek');
     final path = _router?.currentPath();
     if (path == null) {
       return {
@@ -287,7 +307,7 @@ class Agent {
     }
 
     try {
-      GhostOverlay.log('navigate', details: path);
+      GhostOverlay.log('navigate', details: path, kind: 'poke');
       _router!.go(root, path);
       return {'ok': true};
     } catch (e) {
@@ -322,7 +342,7 @@ class Agent {
 
   Future<Map<String, Object?>> _enableSemanticsExtension(
       ExtensionParameters parameters) async {
-    GhostOverlay.log('enable semantics');
+    GhostOverlay.log('enable semantics', kind: 'peek');
     RendererBinding.instance.ensureSemantics();
     await _waitForNextFrame();
     return {};
@@ -356,7 +376,7 @@ class Agent {
 
   Future<Map<String, Object?>> _getSemanticsExtension(
       ExtensionParameters parameters) async {
-    GhostOverlay.log('get semantics');
+    GhostOverlay.log('get semantics', kind: 'peek', viz: 'semantics');
     final (nodes, error) = getSemanticsNodes();
     if (error != null) return {'ok': false, 'error': error};
     return {'ok': true, 'nodes': nodes};
@@ -392,7 +412,8 @@ class Agent {
       ExtensionParameters parameters) async {
     final enabled = parameters.asBoolRequired('enabled');
 
-    GhostOverlay.log('overlays', details: enabled ? 'show' : 'hide');
+    // This command shouldn't have an overlay message.
+    // GhostOverlay.log('overlays', details: enabled ? 'show' : 'hide');
     setOverlaysEnabled(enabled);
 
     await _waitForNextFrame();
@@ -411,7 +432,8 @@ class Agent {
       ParameterDescription(
         name: 'command',
         type: 'String',
-        description: 'Short label for the command, e.g. "reload", "screenshot".',
+        description:
+            'Short label for the command, e.g. "reload", "screenshot".',
         required: true,
       ),
       ParameterDescription(
@@ -420,10 +442,35 @@ class Agent {
         description: 'Optional detail appended after a colon, '
             'e.g. a route path or text value.',
       ),
+      ParameterDescription(
+        name: 'kind',
+        type: 'String',
+        description: 'Icon category hint: "peek", "poke", "reload", or '
+            '"screenshot".',
+      ),
+      ParameterDescription(
+        name: 'finder',
+        type: 'String',
+        description: 'Finder type for the widget of interest '
+            '("byKey", "byType", "byText", "bySemanticsLabel"). '
+            'Used with viz="outline" or viz="layout".',
+      ),
+      ParameterDescription(
+        name: 'finderValue',
+        type: 'String',
+        description: 'Value to match against the chosen finder.',
+      ),
+      ParameterDescription(
+        name: 'viz',
+        type: 'String',
+        description: 'Extra visualization: "flash" (full-screen tint), '
+            '"outline" (widget bounding box), '
+            '"layout" (bounding box with layout annotations), or '
+            '"semantics" (all semantics node outlines).',
+      ),
     ],
     returns: [
-      ReturnDescription(
-          name: 'ok', type: 'bool', description: 'Always true.'),
+      ReturnDescription(name: 'ok', type: 'bool', description: 'Always true.'),
     ],
   );
 
@@ -431,7 +478,16 @@ class Agent {
       ExtensionParameters parameters) async {
     final String command = parameters.asStringRequired('command');
     final String? details = parameters.asString('details');
-    GhostOverlay.log(command, details: details);
+    final String? kind = parameters.asString('kind');
+    final String? finder = parameters.asString('finder');
+    final String? finderValue = parameters.asString('finderValue');
+    final String? viz = parameters.asString('viz');
+    GhostOverlay.log(command,
+        details: details,
+        kind: kind,
+        finder: finder,
+        finderValue: finderValue,
+        viz: viz);
     return {'ok': true};
   }
 

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -6,6 +6,7 @@ import 'package:service_extensions/service_extensions.dart';
 
 import 'actions.dart';
 import 'finder.dart';
+import 'ghost_overlay.dart';
 import 'overlays.dart';
 import 'router_adapter.dart';
 import 'semantics.dart';
@@ -66,6 +67,11 @@ class Agent {
     registerServiceExtension(
       _overlaysDescription,
       _overlaysExtension,
+    );
+
+    registerServiceExtension(
+      _logDescription,
+      _logExtension,
     );
 
     initTelemetry();
@@ -158,11 +164,13 @@ class Agent {
     String? error;
     switch (action) {
       case 'tap':
+        GhostOverlay.log('tap', details: finderValue);
         error = await tapElement(element);
       case 'set_text':
         if (text == null) {
           error = 'interact: "text" is required for the set_text action';
         } else {
+          GhostOverlay.log('set text', details: '"$text"');
           error = setTextInElement(element, text);
         }
       case 'scroll':
@@ -171,6 +179,7 @@ class Agent {
         } else if (pixels == null) {
           error = 'interact: "pixels" is required for the scroll action';
         } else {
+          GhostOverlay.log('scroll', details: '$direction ${pixels}px');
           error = await scrollElement(
             element,
             direction: direction,
@@ -192,6 +201,7 @@ class Agent {
                 'interact: no scrollable found for scrollFinder="$scrollFinder"'
                 ' value="$scrollFinderValue"';
           } else {
+            GhostOverlay.log('scroll to', details: scrollFinderValue);
             error = await scrollUntilVisible(
               targetElement: element,
               scrollableElement: scrollable,
@@ -222,6 +232,7 @@ class Agent {
 
   Future<Map<String, Object?>> _getRouteExtension(
       ExtensionParameters parameters) async {
+    GhostOverlay.log('get route');
     final path = _router?.currentPath();
     if (path == null) {
       return {
@@ -276,6 +287,7 @@ class Agent {
     }
 
     try {
+      GhostOverlay.log('navigate', details: path);
       _router!.go(root, path);
       return {'ok': true};
     } catch (e) {
@@ -309,6 +321,7 @@ class Agent {
 
   Future<Map<String, Object?>> _enableSemanticsExtension(
       ExtensionParameters parameters) async {
+    GhostOverlay.log('enable semantics');
     RendererBinding.instance.ensureSemantics();
     await _waitForNextFrame();
     return {};
@@ -342,6 +355,7 @@ class Agent {
 
   Future<Map<String, Object?>> _getSemanticsExtension(
       ExtensionParameters parameters) async {
+    GhostOverlay.log('get semantics');
     final (nodes, error) = getSemanticsNodes();
     if (error != null) return {'ok': false, 'error': error};
     return {'ok': true, 'nodes': nodes};
@@ -377,10 +391,46 @@ class Agent {
       ExtensionParameters parameters) async {
     final enabled = parameters.asBoolRequired('enabled');
 
+    GhostOverlay.log('overlays', details: enabled ? 'show' : 'hide');
     setOverlaysEnabled(enabled);
 
     await _waitForNextFrame();
 
+    return {'ok': true};
+  }
+
+  final ServiceDescription _logDescription = ServiceDescription(
+    name: 'ext.slipstream.log',
+    description:
+        'Logs an agent command to the ghost overlay command log. Called by the '
+        'Slipstream MCP server for operations that do not flow through an '
+        'in-process extension (e.g. hot reload, screenshot, evaluate). '
+        'In-process extensions log automatically.',
+    parameters: [
+      ParameterDescription(
+        name: 'command',
+        type: 'String',
+        description: 'Short label for the command, e.g. "reload", "screenshot".',
+        required: true,
+      ),
+      ParameterDescription(
+        name: 'details',
+        type: 'String',
+        description: 'Optional detail appended after a colon, '
+            'e.g. a route path or text value.',
+      ),
+    ],
+    returns: [
+      ReturnDescription(
+          name: 'ok', type: 'bool', description: 'Always true.'),
+    ],
+  );
+
+  Future<Map<String, Object?>> _logExtension(
+      ExtensionParameters parameters) async {
+    final String command = parameters.asStringRequired('command');
+    final String? details = parameters.asString('details');
+    GhostOverlay.log(command, details: details);
     return {'ok': true};
   }
 

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -379,7 +379,7 @@ class Agent {
     GhostOverlay.log('get semantics', kind: 'read', viz: 'semantics');
     final (nodes, error) = getSemanticsNodes();
     if (error != null) return {'ok': false, 'error': error};
-    return {'ok': true, 'nodes': nodes};
+    return {'ok': true, 'nodes': nodes!.map((n) => n.toMap()).toList()};
   }
 
   final ServiceDescription _overlaysDescription = ServiceDescription(

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -308,6 +308,7 @@ class Agent {
 
   Future<Map<String, Object?>> _pingExtension(
       ExtensionParameters parameters) async {
+    GhostOverlay.install();
     return {
       'version': packageVersion,
     };

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -94,6 +94,7 @@ class GhostOverlay {
       }
       element.visitChildren(visit);
     }
+
     WidgetsBinding.instance.rootElement?.visitChildren(visit);
     return result;
   }
@@ -110,8 +111,10 @@ class _GhostOverlayWidget extends StatefulWidget {
 }
 
 class _LogEntry {
-  _LogEntry({required this.command, this.details}) : id = _nextId++;
   static int _nextId = 0;
+
+  _LogEntry({required this.command, this.details}) : id = _nextId++;
+
   final int id;
   final String command;
   final String? details;

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -5,15 +5,21 @@ import 'package:flutter/widgets.dart';
 // ---------------------------------------------------------------------------
 // Public API
 
-/// Displays a transient command log above the app's widget tree.
+/// Displays a transient command log and a "slipstream" banner above the app's
+/// widget tree.
 ///
-/// Call [log] to add an entry. The overlay locates the first [OverlayState]
-/// in the widget tree and inserts itself lazily — no app-side setup is
-/// required beyond calling [SlipstreamAgent.init].
+/// Call [install] once (e.g. on the first [ext.slipstream.ping]) to disable
+/// the Flutter debug banner and show the Slipstream banner. Call [log] to add
+/// command-log entries. Call [setVisible] to hide/show everything (e.g. before
+/// taking a screenshot).
 ///
-/// Each entry is shown for [_displayDuration] and then removed. When the
+/// The overlay locates the first [OverlayState] in the widget tree and inserts
+/// itself lazily — no app-side setup is required beyond calling
+/// [SlipstreamAgent.init].
+///
+/// Each log entry is shown for [_displayDuration] and then removed. When the
 /// overlay has been removed from the tree (e.g. after a hot restart), it
-/// reinstalls itself on the next [log] call.
+/// reinstalls itself on the next [log] or [install] call.
 class GhostOverlay {
   GhostOverlay._();
 
@@ -26,24 +32,39 @@ class GhostOverlay {
   /// The queue of (command, details) pairs waiting to be handed to the widget.
   static final List<(String, String?)> _pending = [];
 
-  /// Controls whether the ghost overlay is visible.
+  static bool _visible = true;
+
+  /// Installs the ghost overlay and permanently disables the Flutter debug
+  /// banner for the life of the Slipstream session.
   ///
-  /// Set to `false` to suppress new entries and clear any currently visible
-  /// chips (e.g. before taking a screenshot). Set back to `true` to resume
-  /// normal display. Mirrors the role of [WidgetsApp.debugAllowBannerOverride]
-  /// for the debug banner.
-  static bool overlayEnabled = true;
+  /// Safe to call multiple times — subsequent calls are no-ops unless the
+  /// overlay was removed from the tree (e.g. after a hot restart).
+  static void install() {
+    _ensureInstalled();
+  }
 
   /// Shows [command] (and optional [details]) in the command log overlay.
   ///
-  /// If [overlayEnabled] is `false` the call is silently ignored.
-  /// If the overlay is not yet in the tree it is installed first; any entries
-  /// that arrive before the first build are queued and replayed once the
-  /// widget state is available.
+  /// If the overlay is hidden (see [setVisible]) the entry is silently
+  /// ignored. If the overlay is not yet in the tree it is installed first;
+  /// any entries that arrive before the first build are queued and replayed
+  /// once the widget state is available.
   static void log(String command, {String? details}) {
-    if (!overlayEnabled) return;
+    if (!_visible) return;
     _pending.add((command, details));
     _ensureInstalled();
+  }
+
+  /// Shows or hides the entire ghost overlay (banner + chips).
+  ///
+  /// Pass `false` before taking a screenshot to remove all Slipstream UI;
+  /// pass `true` to restore it.
+  static void setVisible(bool visible) {
+    _visible = visible;
+    if (!visible) {
+      _pending.clear();
+    }
+    _key.currentState?.setVisible(visible);
   }
 
   /// Clears all currently visible chips immediately.
@@ -67,6 +88,9 @@ class GhostOverlay {
       WidgetsBinding.instance.addPostFrameCallback((_) => _ensureInstalled());
       return;
     }
+
+    // Permanently disable the Flutter debug banner for this session.
+    WidgetsApp.debugAllowBannerOverride = false;
 
     _entry = OverlayEntry(builder: (_) => _GhostOverlayWidget(key: _key));
     overlay.insert(_entry!);
@@ -103,6 +127,10 @@ class GhostOverlay {
 // ---------------------------------------------------------------------------
 // Widget
 
+// Slipstream blue.
+const Color ghostOverlayColor = Color(0xFF1565C0);
+// const Color ghostOverlayColor = Color(0xA01565C0);
+
 class _GhostOverlayWidget extends StatefulWidget {
   const _GhostOverlayWidget({super.key});
 
@@ -122,21 +150,53 @@ class _LogEntry {
 
 class _GhostOverlayState extends State<_GhostOverlayWidget> {
   final List<_LogEntry> _entries = [];
+  final Map<int, GlobalKey<_EntryChipState>> _chipKeys = {};
   final List<Timer> _timers = [];
+
+  bool _visible = true;
+
+  void setVisible(bool visible) {
+    if (!mounted) return;
+    if (visible == _visible) return;
+    if (!visible) {
+      for (final t in _timers) {
+        t.cancel();
+      }
+      _timers.clear();
+    }
+    setState(() {
+      _visible = visible;
+      if (!visible) {
+        _entries.clear();
+        _chipKeys.clear();
+      }
+    });
+  }
 
   void addEntry(String command, String? details) {
     if (!mounted) return;
     final entry = _LogEntry(command: command, details: details);
+    final key = GlobalKey<_EntryChipState>();
     setState(() {
-      _entries.add(entry);
-      if (_entries.length > GhostOverlay._maxEntries) {
-        _entries.removeAt(0);
+      if (_entries.length >= GhostOverlay._maxEntries) {
+        final oldest = _entries.removeAt(0);
+        _chipKeys.remove(oldest.id);
       }
+      _entries.add(entry);
+      _chipKeys[entry.id] = key;
     });
     _timers.add(Timer(GhostOverlay._displayDuration, () {
       if (!mounted) return;
-      setState(() => _entries.removeWhere((e) => e.id == entry.id));
+      _chipKeys[entry.id]?.currentState?.triggerExit();
     }));
+  }
+
+  void _onChipExited(_LogEntry entry) {
+    if (!mounted) return;
+    setState(() {
+      _entries.removeWhere((e) => e.id == entry.id);
+      _chipKeys.remove(entry.id);
+    });
   }
 
   void clearEntries() {
@@ -145,7 +205,10 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
       t.cancel();
     }
     _timers.clear();
-    setState(() => _entries.clear());
+    setState(() {
+      _entries.clear();
+      _chipKeys.clear();
+    });
   }
 
   @override
@@ -158,56 +221,152 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
 
   @override
   Widget build(BuildContext context) {
-    if (_entries.isEmpty) return const SizedBox.shrink();
+    if (!_visible) return const SizedBox.shrink();
 
     // OverlayEntry builds inside the Overlay's Stack, so Positioned works
     // directly here. Use MediaQuery for safe-area insets when available.
     final bottomInset = MediaQuery.maybePaddingOf(context)?.bottom ?? 0.0;
 
-    return Positioned(
-      bottom: bottomInset + 12,
-      right: 12,
-      child: IgnorePointer(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.end,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            for (final entry in _entries) _EntryChip(entry: entry),
-          ],
-        ),
+    return IgnorePointer(
+      child: Stack(
+        children: [
+          // Slipstream banner — replaces the Flutter debug banner in the
+          // top-right corner.
+          Positioned.fill(
+            child: CustomPaint(
+              painter: BannerPainter(
+                message: 'slipstream',
+                textDirection: TextDirection.ltr,
+                layoutDirection: TextDirection.ltr,
+                location: BannerLocation.topEnd,
+                color: ghostOverlayColor,
+              ),
+            ),
+          ),
+          // Command-log chip stack in the bottom-right corner.
+          if (_entries.isNotEmpty)
+            Positioned(
+              bottom: bottomInset + 24,
+              right: 12,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  for (final entry in _entries)
+                    _EntryChip(
+                      key: _chipKeys[entry.id],
+                      entry: entry,
+                      onExited: () => _onChipExited(entry),
+                    ),
+                ],
+              ),
+            ),
+        ],
       ),
     );
   }
 }
 
-class _EntryChip extends StatelessWidget {
-  const _EntryChip({required this.entry});
+class _EntryChip extends StatefulWidget {
+  const _EntryChip({super.key, required this.entry, required this.onExited});
 
   final _LogEntry entry;
+  final VoidCallback onExited;
+
+  @override
+  State<_EntryChip> createState() => _EntryChipState();
+}
+
+class _EntryChipState extends State<_EntryChip> with TickerProviderStateMixin {
+  static const Duration _animDuration = Duration(milliseconds: 280);
+
+  late final AnimationController _enterController;
+  late final AnimationController _exitController;
+  late final Animation<Offset> _enterSlide;
+  late final Animation<Offset> _exitSlide;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _enterController = AnimationController(vsync: this, duration: _animDuration)
+      ..forward();
+    _exitController = AnimationController(vsync: this, duration: _animDuration);
+
+    _enterSlide = Tween<Offset>(
+      begin: const Offset(1.5, 0),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _enterController, curve: Curves.easeOut));
+
+    _exitSlide = Tween<Offset>(
+      begin: Offset.zero,
+      end: const Offset(1.5, 0),
+    ).animate(CurvedAnimation(parent: _exitController, curve: Curves.easeIn));
+  }
+
+  /// Plays the exit animation then calls [_EntryChip.onExited].
+  void triggerExit() {
+    if (!mounted) return;
+    if (_exitController.isAnimating || _exitController.isCompleted) return;
+    _exitController.forward().then((_) {
+      if (mounted) widget.onExited();
+    });
+  }
+
+  @override
+  void dispose() {
+    _enterController.dispose();
+    _exitController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final label = entry.details != null
-        ? '${entry.command}: ${entry.details}'
-        : entry.command;
+    final label = widget.entry.details != null
+        ? '${widget.entry.command}: ${widget.entry.details}'
+        : widget.entry.command;
 
     return Padding(
-      padding: const EdgeInsets.only(top: 4),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          // Slipstream blue, semi-opaque so the app beneath remains visible.
-          color: const Color(0xE01565C0),
-          borderRadius: BorderRadius.circular(14),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-          child: Text(
-            label,
-            style: const TextStyle(
-              color: Color(0xFFFFFFFF),
-              fontSize: 13,
-              fontWeight: FontWeight.normal,
-              decoration: TextDecoration.none,
+      padding: const EdgeInsets.only(top: 8),
+      child: ClipRect(
+        child: AnimatedBuilder(
+          animation: Listenable.merge([_enterController, _exitController]),
+          builder: (context, child) => FractionalTranslation(
+            translation: _enterSlide.value + _exitSlide.value,
+            child: child,
+          ),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  Color.alphaBlend(const Color(0x28FFFFFF), ghostOverlayColor),
+                  ghostOverlayColor,
+                ],
+              ),
+              borderRadius: BorderRadius.circular(6),
+              boxShadow: const [
+                BoxShadow(
+                  color: Color(0x55000000),
+                  blurRadius: 6,
+                  offset: Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  color: Color(0xFFFFFFFF),
+                  fontSize: 12 * 0.85,
+                  fontWeight: FontWeight.w900,
+                  decoration: TextDecoration.none,
+                ),
+              ),
             ),
           ),
         ),

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -45,7 +45,7 @@ class GhostOverlay {
 
   /// Shows [command] (and optional [details]) in the command log overlay.
   ///
-  /// [kind] hints which icon to display: `"peek"`, `"poke"`, `"reload"`, or
+  /// [kind] hints which icon to display: `"read"`, `"interact"`, `"reload"`, or
   /// `"screenshot"`. [finder] + [finderValue] identify a widget of interest
   /// for visualizations. [viz] names an extra visual effect: `"flash"`,
   /// `"outline"`, `"layout"`, or `"semantics"`.
@@ -173,7 +173,7 @@ class _LogEntry {
   final String command;
   final String? details;
 
-  /// Icon category hint: `"peek"`, `"poke"`, `"reload"`, or `"screenshot"`.
+  /// Icon category hint: `"read"`, `"interact"`, `"reload"`, or `"screenshot"`.
   final String? kind;
 
   /// Finder type for the widget of interest (same values as `perform_action`).

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -26,14 +26,30 @@ class GhostOverlay {
   /// The queue of (command, details) pairs waiting to be handed to the widget.
   static final List<(String, String?)> _pending = [];
 
+  /// Controls whether the ghost overlay is visible.
+  ///
+  /// Set to `false` to suppress new entries and clear any currently visible
+  /// chips (e.g. before taking a screenshot). Set back to `true` to resume
+  /// normal display. Mirrors the role of [WidgetsApp.debugAllowBannerOverride]
+  /// for the debug banner.
+  static bool overlayEnabled = true;
+
   /// Shows [command] (and optional [details]) in the command log overlay.
   ///
+  /// If [overlayEnabled] is `false` the call is silently ignored.
   /// If the overlay is not yet in the tree it is installed first; any entries
   /// that arrive before the first build are queued and replayed once the
   /// widget state is available.
   static void log(String command, {String? details}) {
+    if (!overlayEnabled) return;
     _pending.add((command, details));
     _ensureInstalled();
+  }
+
+  /// Clears all currently visible chips immediately.
+  static void clearEntries() {
+    _pending.clear();
+    _key.currentState?.clearEntries();
   }
 
   // ---------------------------------------------------------------------------
@@ -118,6 +134,15 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
       if (!mounted) return;
       setState(() => _entries.removeWhere((e) => e.id == entry.id));
     }));
+  }
+
+  void clearEntries() {
+    if (!mounted) return;
+    for (final t in _timers) {
+      t.cancel();
+    }
+    _timers.clear();
+    setState(() => _entries.clear());
   }
 
   @override

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -200,9 +200,14 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
 
   bool _visible = true;
 
-  final _flashKey = GlobalKey<_FlashOverlayState>();
-  final _outlineKey = GlobalKey<_OutlineOverlayState>();
-  final _semanticsKey = GlobalKey<_SemanticsOverlayState>();
+  // Trigger counters and data for the three visualization sub-widgets.
+  // Incrementing a counter causes the corresponding widget to start its
+  // animation via didUpdateWidget; no GlobalKeys needed.
+  int _flashCount = 0;
+  Rect? _outlineRect;
+  int _outlineCount = 0;
+  List<({Rect rect, String label})> _semanticsRects = const [];
+  int _semanticsCount = 0;
 
   void setVisible(bool visible) {
     if (!mounted) return;
@@ -212,15 +217,14 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
         t.cancel();
       }
       _timers.clear();
-      _flashKey.currentState?.reset();
-      _outlineKey.currentState?.reset();
-      _semanticsKey.currentState?.reset();
     }
     setState(() {
       _visible = visible;
       if (!visible) {
         _entries.clear();
         _chipKeys.clear();
+        _outlineRect = null;
+        _semanticsRects = const [];
       }
     });
   }
@@ -242,7 +246,7 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
       _chipKeys[existing.id]?.currentState?.triggerExit();
     }
 
-    if (entry.viz == 'flash') _flashKey.currentState?.trigger();
+    if (entry.viz == 'flash') setState(() => _flashCount++);
     if (entry.viz == 'outline' &&
         entry.finder != null &&
         entry.finderValue != null) {
@@ -261,7 +265,10 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
     final box = el?.renderObject;
     if (box is RenderBox && box.hasSize) {
       final rect = box.localToGlobal(Offset.zero) & box.size;
-      _outlineKey.currentState?.trigger(rect);
+      setState(() {
+        _outlineRect = rect;
+        _outlineCount++;
+      });
     }
   }
 
@@ -277,15 +284,10 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
         ),
     ];
 
-    // Sort largest area first so that container nodes are painted behind
-    // smaller, more specific nodes in the Stack.
-    rects.sort((a, b) {
-      final aArea = a.rect.width * a.rect.height;
-      final bArea = b.rect.width * b.rect.height;
-      return bArea.compareTo(aArea);
+    setState(() {
+      _semanticsRects = rects;
+      _semanticsCount++;
     });
-
-    _semanticsKey.currentState?.trigger(rects);
   }
 
   static String _semanticsLabel(SemanticsNodeInfo node) {
@@ -310,11 +312,11 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
       t.cancel();
     }
     _timers.clear();
-    _outlineKey.currentState?.reset();
-    _semanticsKey.currentState?.reset();
     setState(() {
       _entries.clear();
       _chipKeys.clear();
+      _outlineRect = null;
+      _semanticsRects = const [];
     });
   }
 
@@ -336,11 +338,12 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
       child: Stack(
         children: [
           // Brief white full-screen tint for viz:"flash" entries.
-          _FlashOverlay(key: _flashKey),
+          _FlashOverlay(triggerCount: _flashCount),
           // Bounding-box highlight for viz:"outline" entries.
-          _OutlineOverlay(key: _outlineKey),
+          _OutlineOverlay(rect: _outlineRect, triggerCount: _outlineCount),
           // Per-node bounding boxes for viz:"semantics" entries.
-          _SemanticsOverlay(key: _semanticsKey),
+          _SemanticsOverlay(
+              rects: _semanticsRects, triggerCount: _semanticsCount),
           // Slipstream banner — replaces the Flutter debug banner.
           Positioned.fill(
             child: CustomPaint(
@@ -382,9 +385,11 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
 // ---------------------------------------------------------------------------
 // Visualization widgets
 
-/// Brief full-screen white tint. Trigger with [trigger]; reset with [reset].
+/// Brief full-screen white tint, triggered when [triggerCount] increments.
 class _FlashOverlay extends StatefulWidget {
-  const _FlashOverlay({super.key});
+  const _FlashOverlay({required this.triggerCount});
+
+  final int triggerCount;
 
   @override
   State<_FlashOverlay> createState() => _FlashOverlayState();
@@ -412,8 +417,13 @@ class _FlashOverlayState extends State<_FlashOverlay>
     ]).animate(_controller);
   }
 
-  void trigger() => _controller.forward(from: 0.0);
-  void reset() => _controller.reset();
+  @override
+  void didUpdateWidget(_FlashOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.triggerCount != oldWidget.triggerCount) {
+      _controller.forward(from: 0.0);
+    }
+  }
 
   @override
   void dispose() {
@@ -438,9 +448,12 @@ class _FlashOverlayState extends State<_FlashOverlay>
 }
 
 /// Animated bounding-box highlight for a single widget.
-/// Call [trigger] with the screen-space rect; [reset] to hide immediately.
+/// Starts its animation when [triggerCount] increments; hides when [rect] is null.
 class _OutlineOverlay extends StatefulWidget {
-  const _OutlineOverlay({super.key});
+  const _OutlineOverlay({required this.rect, required this.triggerCount});
+
+  final Rect? rect;
+  final int triggerCount;
 
   @override
   State<_OutlineOverlay> createState() => _OutlineOverlayState();
@@ -450,7 +463,6 @@ class _OutlineOverlayState extends State<_OutlineOverlay>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late final Animation<double> _opacity;
-  Rect? _rect;
 
   @override
   void initState() {
@@ -472,14 +484,14 @@ class _OutlineOverlayState extends State<_OutlineOverlay>
     ]).animate(_controller);
   }
 
-  void trigger(Rect rect) {
-    setState(() => _rect = rect);
-    _controller.forward(from: 0.0);
-  }
-
-  void reset() {
-    _controller.reset();
-    if (mounted) setState(() => _rect = null);
+  @override
+  void didUpdateWidget(_OutlineOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.rect == null) {
+      _controller.reset();
+    } else if (widget.triggerCount != oldWidget.triggerCount) {
+      _controller.forward(from: 0.0);
+    }
   }
 
   @override
@@ -490,7 +502,7 @@ class _OutlineOverlayState extends State<_OutlineOverlay>
 
   @override
   Widget build(BuildContext context) {
-    final rect = _rect;
+    final rect = widget.rect;
     if (rect == null) return const SizedBox.shrink();
     return AnimatedBuilder(
       animation: _controller,
@@ -514,9 +526,12 @@ class _OutlineOverlayState extends State<_OutlineOverlay>
 }
 
 /// Animated bounding-box overlay for all visible semantics nodes.
-/// Call [trigger] with the sorted rect+label list; [reset] to hide immediately.
+/// Starts its animation when [triggerCount] increments; hides when [rects] is empty.
 class _SemanticsOverlay extends StatefulWidget {
-  const _SemanticsOverlay({super.key});
+  const _SemanticsOverlay({required this.rects, required this.triggerCount});
+
+  final List<({Rect rect, String label})> rects;
+  final int triggerCount;
 
   @override
   State<_SemanticsOverlay> createState() => _SemanticsOverlayState();
@@ -526,7 +541,6 @@ class _SemanticsOverlayState extends State<_SemanticsOverlay>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late final Animation<double> _opacity;
-  List<({Rect rect, String label})> _rects = [];
 
   @override
   void initState() {
@@ -545,14 +559,14 @@ class _SemanticsOverlayState extends State<_SemanticsOverlay>
     ]).animate(_controller);
   }
 
-  void trigger(List<({Rect rect, String label})> rects) {
-    setState(() => _rects = rects);
-    _controller.forward(from: 0.0);
-  }
-
-  void reset() {
-    _controller.reset();
-    if (mounted) setState(() => _rects = []);
+  @override
+  void didUpdateWidget(_SemanticsOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.rects.isEmpty) {
+      _controller.reset();
+    } else if (widget.triggerCount != oldWidget.triggerCount) {
+      _controller.forward(from: 0.0);
+    }
   }
 
   @override
@@ -563,7 +577,7 @@ class _SemanticsOverlayState extends State<_SemanticsOverlay>
 
   @override
   Widget build(BuildContext context) {
-    if (_rects.isEmpty) return const SizedBox.shrink();
+    if (widget.rects.isEmpty) return const SizedBox.shrink();
     return AnimatedBuilder(
       animation: _controller,
       builder: (context, _) {
@@ -571,7 +585,7 @@ class _SemanticsOverlayState extends State<_SemanticsOverlay>
         final opacity = _opacity.value;
         return Stack(
           children: [
-            for (final item in _rects)
+            for (final item in widget.rects)
               Positioned.fromRect(
                 rect: item.rect.deflate(1.5),
                 child: Opacity(

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -1,6 +1,10 @@
 import 'dart:async';
 
+import 'package:flutter/material.dart' show Icons;
 import 'package:flutter/widgets.dart';
+
+import 'finder.dart';
+import 'semantics.dart';
 
 // ---------------------------------------------------------------------------
 // Public API
@@ -17,20 +21,21 @@ import 'package:flutter/widgets.dart';
 /// itself lazily — no app-side setup is required beyond calling
 /// [SlipstreamAgent.init].
 ///
-/// Each log entry is shown for [_displayDuration] and then removed. When the
+/// Each log entry is shown for [_chipDuration] and then removed. When the
 /// overlay has been removed from the tree (e.g. after a hot restart), it
 /// reinstalls itself on the next [log] or [install] call.
 class GhostOverlay {
   GhostOverlay._();
 
-  static const Duration _displayDuration = Duration(seconds: 3);
-  static const int _maxEntries = 5;
+  static const Duration _chipDuration = Duration(seconds: 3);
+  static const Duration _semanticsDuration = Duration(seconds: 3);
+  static const Duration _outlineDuration = Duration(milliseconds: 900);
 
   static final GlobalKey<_GhostOverlayState> _key = GlobalKey();
   static OverlayEntry? _entry;
 
   /// The queue of entries waiting to be handed to the widget.
-  static final List<_LogEntry> _pending = [];
+  static final List<_LogMessage> _pending = [];
 
   static bool _visible = true;
 
@@ -63,7 +68,7 @@ class GhostOverlay {
     String? viz,
   }) {
     if (!_visible) return;
-    _pending.add(_LogEntry(
+    _pending.add(_LogMessage(
       command: command,
       details: details,
       kind: kind,
@@ -122,7 +127,7 @@ class GhostOverlay {
     final state = _key.currentState;
     if (state == null || _pending.isEmpty) return;
     for (final entry in _pending) {
-      state.addEntry(entry);
+      state.addLogMessage(entry);
     }
     _pending.clear();
   }
@@ -148,7 +153,6 @@ class GhostOverlay {
 
 // Slipstream blue.
 const Color ghostOverlayColor = Color(0xFF1565C0);
-// const Color ghostOverlayColor = Color(0xA01565C0);
 
 class _GhostOverlayWidget extends StatefulWidget {
   const _GhostOverlayWidget({super.key});
@@ -157,10 +161,10 @@ class _GhostOverlayWidget extends StatefulWidget {
   State<_GhostOverlayWidget> createState() => _GhostOverlayState();
 }
 
-class _LogEntry {
+class _LogMessage {
   static int _nextId = 0;
 
-  _LogEntry({
+  _LogMessage({
     required this.command,
     this.details,
     this.kind,
@@ -186,12 +190,19 @@ class _LogEntry {
   final String? viz;
 }
 
+// ---------------------------------------------------------------------------
+// Ghost overlay state
+
 class _GhostOverlayState extends State<_GhostOverlayWidget> {
-  final List<_LogEntry> _entries = [];
+  final List<_LogMessage> _entries = [];
   final Map<int, GlobalKey<_EntryChipState>> _chipKeys = {};
   final List<Timer> _timers = [];
 
   bool _visible = true;
+
+  final _flashKey = GlobalKey<_FlashOverlayState>();
+  final _outlineKey = GlobalKey<_OutlineOverlayState>();
+  final _semanticsKey = GlobalKey<_SemanticsOverlayState>();
 
   void setVisible(bool visible) {
     if (!mounted) return;
@@ -201,6 +212,9 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
         t.cancel();
       }
       _timers.clear();
+      _flashKey.currentState?.reset();
+      _outlineKey.currentState?.reset();
+      _semanticsKey.currentState?.reset();
     }
     setState(() {
       _visible = visible;
@@ -211,24 +225,78 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
     });
   }
 
-  void addEntry(_LogEntry entry) {
+  void addLogMessage(_LogMessage entry) {
     if (!mounted) return;
+
+    // Capture currently visible chips — they'll be bumped out immediately.
+    final toExit = List.of(_entries);
+
     final key = GlobalKey<_EntryChipState>();
     setState(() {
-      if (_entries.length >= GhostOverlay._maxEntries) {
-        final oldest = _entries.removeAt(0);
-        _chipKeys.remove(oldest.id);
-      }
       _entries.add(entry);
       _chipKeys[entry.id] = key;
     });
-    _timers.add(Timer(GhostOverlay._displayDuration, () {
+
+    // Bump any existing chip out now rather than waiting for its timer.
+    for (final existing in toExit) {
+      _chipKeys[existing.id]?.currentState?.triggerExit();
+    }
+
+    if (entry.viz == 'flash') _flashKey.currentState?.trigger();
+    if (entry.viz == 'outline' &&
+        entry.finder != null &&
+        entry.finderValue != null) {
+      _triggerOutline(entry.finder!, entry.finderValue!);
+    }
+    if (entry.viz == 'semantics') _triggerSemantics();
+
+    _timers.add(Timer(GhostOverlay._chipDuration, () {
       if (!mounted) return;
       _chipKeys[entry.id]?.currentState?.triggerExit();
     }));
   }
 
-  void _onChipExited(_LogEntry entry) {
+  void _triggerOutline(String finder, String finderValue) {
+    final el = findElement(finder: finder, value: finderValue);
+    final box = el?.renderObject;
+    if (box is RenderBox && box.hasSize) {
+      final rect = box.localToGlobal(Offset.zero) & box.size;
+      _outlineKey.currentState?.trigger(rect);
+    }
+  }
+
+  void _triggerSemantics() {
+    final (nodes, _) = getSemanticsNodes();
+    if (nodes == null || nodes.isEmpty) return;
+
+    final rects = [
+      for (final node in nodes)
+        (
+          rect: node.screenRect,
+          label: _semanticsLabel(node),
+        ),
+    ];
+
+    // Sort largest area first so that container nodes are painted behind
+    // smaller, more specific nodes in the Stack.
+    rects.sort((a, b) {
+      final aArea = a.rect.width * a.rect.height;
+      final bArea = b.rect.width * b.rect.height;
+      return bArea.compareTo(aArea);
+    });
+
+    _semanticsKey.currentState?.trigger(rects);
+  }
+
+  static String _semanticsLabel(SemanticsNodeInfo node) {
+    final label = node.label.trim();
+    if (label.isNotEmpty) {
+      return label.length > 18 ? '${label.substring(0, 16)}…' : label;
+    }
+    return node.role ?? 'text';
+  }
+
+  void _onChipExited(_LogMessage entry) {
     if (!mounted) return;
     setState(() {
       _entries.removeWhere((e) => e.id == entry.id);
@@ -242,6 +310,8 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
       t.cancel();
     }
     _timers.clear();
+    _outlineKey.currentState?.reset();
+    _semanticsKey.currentState?.reset();
     setState(() {
       _entries.clear();
       _chipKeys.clear();
@@ -260,15 +330,18 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
   Widget build(BuildContext context) {
     if (!_visible) return const SizedBox.shrink();
 
-    // OverlayEntry builds inside the Overlay's Stack, so Positioned works
-    // directly here. Use MediaQuery for safe-area insets when available.
     final bottomInset = MediaQuery.maybePaddingOf(context)?.bottom ?? 0.0;
 
     return IgnorePointer(
       child: Stack(
         children: [
-          // Slipstream banner — replaces the Flutter debug banner in the
-          // top-right corner.
+          // Brief white full-screen tint for viz:"flash" entries.
+          _FlashOverlay(key: _flashKey),
+          // Bounding-box highlight for viz:"outline" entries.
+          _OutlineOverlay(key: _outlineKey),
+          // Per-node bounding boxes for viz:"semantics" entries.
+          _SemanticsOverlay(key: _semanticsKey),
+          // Slipstream banner — replaces the Flutter debug banner.
           Positioned.fill(
             child: CustomPaint(
               painter: BannerPainter(
@@ -280,14 +353,16 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
               ),
             ),
           ),
-          // Command-log chip stack in the bottom-right corner.
+          // Command-log chips — share the same space; newer chips are
+          // painted in front of older ones.
           if (_entries.isNotEmpty)
             Positioned(
-              bottom: bottomInset + 24,
+              bottom: bottomInset + 36,
+              left: 12,
               right: 12,
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                mainAxisSize: MainAxisSize.min,
+              child: Stack(
+                alignment: Alignment.center,
+                clipBehavior: Clip.none,
                 children: [
                   for (final entry in _entries)
                     _EntryChip(
@@ -304,10 +379,268 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Visualization widgets
+
+/// Brief full-screen white tint. Trigger with [trigger]; reset with [reset].
+class _FlashOverlay extends StatefulWidget {
+  const _FlashOverlay({super.key});
+
+  @override
+  State<_FlashOverlay> createState() => _FlashOverlayState();
+}
+
+class _FlashOverlayState extends State<_FlashOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    );
+    // Quick fade-in → brief hold → slow fade-out.
+    _opacity = TweenSequence<double>([
+      TweenSequenceItem(
+          tween: Tween(begin: 0.0, end: 0.65), weight: 12), // ~72ms
+      TweenSequenceItem(tween: ConstantTween(0.65), weight: 13), // ~78ms hold
+      TweenSequenceItem(
+          tween: Tween(begin: 0.65, end: 0.0), weight: 75), // ~450ms
+    ]).animate(_controller);
+  }
+
+  void trigger() => _controller.forward(from: 0.0);
+  void reset() => _controller.reset();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        if (_controller.isDismissed) return const SizedBox.shrink();
+        return Positioned.fill(
+          child: ColoredBox(
+            color: Color.fromRGBO(255, 255, 255, _opacity.value),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Animated bounding-box highlight for a single widget.
+/// Call [trigger] with the screen-space rect; [reset] to hide immediately.
+class _OutlineOverlay extends StatefulWidget {
+  const _OutlineOverlay({super.key});
+
+  @override
+  State<_OutlineOverlay> createState() => _OutlineOverlayState();
+}
+
+class _OutlineOverlayState extends State<_OutlineOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+  Rect? _rect;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: GhostOverlay._outlineDuration,
+    );
+    // Double flash: fade-in → fade-out → fade-in → fade-out.
+    _opacity = TweenSequence<double>([
+      TweenSequenceItem(
+          tween: Tween(begin: 0.0, end: 1.0), weight: 15), // ~135ms
+      TweenSequenceItem(
+          tween: Tween(begin: 1.0, end: 0.0), weight: 20), // ~180ms
+      TweenSequenceItem(
+          tween: Tween(begin: 0.0, end: 1.0), weight: 15), // ~135ms
+      TweenSequenceItem(
+          tween: Tween(begin: 1.0, end: 0.0), weight: 50), // ~450ms
+    ]).animate(_controller);
+  }
+
+  void trigger(Rect rect) {
+    setState(() => _rect = rect);
+    _controller.forward(from: 0.0);
+  }
+
+  void reset() {
+    _controller.reset();
+    if (mounted) setState(() => _rect = null);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final rect = _rect;
+    if (rect == null) return const SizedBox.shrink();
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        if (_controller.isDismissed) return const SizedBox.shrink();
+        return Positioned.fromRect(
+          rect: rect.inflate(3),
+          child: Opacity(
+            opacity: _opacity.value,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                border: Border.all(color: ghostOverlayColor, width: 2),
+                borderRadius: BorderRadius.circular(4),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// Animated bounding-box overlay for all visible semantics nodes.
+/// Call [trigger] with the sorted rect+label list; [reset] to hide immediately.
+class _SemanticsOverlay extends StatefulWidget {
+  const _SemanticsOverlay({super.key});
+
+  @override
+  State<_SemanticsOverlay> createState() => _SemanticsOverlayState();
+}
+
+class _SemanticsOverlayState extends State<_SemanticsOverlay>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _opacity;
+  List<({Rect rect, String label})> _rects = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: GhostOverlay._semanticsDuration,
+    );
+    // Fade-in → hold → fade-out.
+    _opacity = TweenSequence<double>([
+      TweenSequenceItem(
+          tween: Tween(begin: 0.0, end: 1.0), weight: 10), // ~300ms
+      TweenSequenceItem(tween: ConstantTween(1.0), weight: 60), // ~1800ms hold
+      TweenSequenceItem(
+          tween: Tween(begin: 1.0, end: 0.0), weight: 30), // ~900ms
+    ]).animate(_controller);
+  }
+
+  void trigger(List<({Rect rect, String label})> rects) {
+    setState(() => _rects = rects);
+    _controller.forward(from: 0.0);
+  }
+
+  void reset() {
+    _controller.reset();
+    if (mounted) setState(() => _rects = []);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_rects.isEmpty) return const SizedBox.shrink();
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, _) {
+        if (_controller.isDismissed) return const SizedBox.shrink();
+        final opacity = _opacity.value;
+        return Stack(
+          children: [
+            for (final item in _rects)
+              Positioned.fromRect(
+                rect: item.rect.deflate(1.5),
+                child: Opacity(
+                  opacity: opacity,
+                  child: _SemanticsNodeWidget(label: item.label),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// Border box with a small label badge in the top-right corner, used to
+/// render a single semantics node in the [_SemanticsOverlay].
+class _SemanticsNodeWidget extends StatelessWidget {
+  const _SemanticsNodeWidget({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            border: Border.all(color: ghostOverlayColor, width: 1.5),
+          ),
+          child: const SizedBox.expand(),
+        ),
+        if (label.isNotEmpty)
+          Positioned(
+            top: -1,
+            right: -1,
+            child: DecoratedBox(
+              decoration: const BoxDecoration(
+                color: ghostOverlayColor,
+                borderRadius: BorderRadius.only(
+                  bottomLeft: Radius.circular(3),
+                ),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 3, vertical: 1),
+                child: Text(
+                  label,
+                  style: const TextStyle(
+                    color: Color(0xFFFFFFFF),
+                    fontSize: 8,
+                    fontWeight: FontWeight.w700,
+                    decoration: TextDecoration.none,
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command-log chip
+
 class _EntryChip extends StatefulWidget {
   const _EntryChip({super.key, required this.entry, required this.onExited});
 
-  final _LogEntry entry;
+  final _LogMessage entry;
   final VoidCallback onExited;
 
   @override
@@ -330,14 +663,15 @@ class _EntryChipState extends State<_EntryChip> with TickerProviderStateMixin {
       ..forward();
     _exitController = AnimationController(vsync: this, duration: _animDuration);
 
+    // Values are fractions of the screen height (0.1 = 10% of screen height).
     _enterSlide = Tween<Offset>(
-      begin: const Offset(1.5, 0),
+      begin: const Offset(0, 0.1),
       end: Offset.zero,
     ).animate(CurvedAnimation(parent: _enterController, curve: Curves.easeOut));
 
     _exitSlide = Tween<Offset>(
       begin: Offset.zero,
-      end: const Offset(1.5, 0),
+      end: const Offset(0, 0.1),
     ).animate(CurvedAnimation(parent: _exitController, curve: Curves.easeIn));
   }
 
@@ -357,43 +691,57 @@ class _EntryChipState extends State<_EntryChip> with TickerProviderStateMixin {
     super.dispose();
   }
 
+  static IconData? _iconForKind(String? kind) => switch (kind) {
+        'reload' => Icons.refresh,
+        'screenshot' => Icons.photo_camera,
+        'read' => Icons.visibility,
+        'interact' => Icons.touch_app,
+        _ => null,
+      };
+
   @override
   Widget build(BuildContext context) {
     final label = widget.entry.details != null
         ? '${widget.entry.command}: ${widget.entry.details}'
         : widget.entry.command;
+    final icon = _iconForKind(widget.entry.kind);
 
-    return Padding(
-      padding: const EdgeInsets.only(top: 8),
-      child: ClipRect(
-        child: AnimatedBuilder(
-          animation: Listenable.merge([_enterController, _exitController]),
-          builder: (context, child) => FractionalTranslation(
-            translation: _enterSlide.value + _exitSlide.value,
-            child: child,
+    return AnimatedBuilder(
+      animation: Listenable.merge([_enterController, _exitController]),
+      builder: (context, child) {
+        final screenH = MediaQuery.sizeOf(context).height;
+        final dy = (_enterSlide.value.dy + _exitSlide.value.dy) * screenH;
+        return Transform.translate(offset: Offset(0, dy), child: child);
+      },
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [
+              Color.alphaBlend(const Color(0x28FFFFFF), ghostOverlayColor),
+              ghostOverlayColor,
+            ],
           ),
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [
-                  Color.alphaBlend(const Color(0x28FFFFFF), ghostOverlayColor),
-                  ghostOverlayColor,
-                ],
-              ),
-              borderRadius: BorderRadius.circular(6),
-              boxShadow: const [
-                BoxShadow(
-                  color: Color(0x55000000),
-                  blurRadius: 6,
-                  offset: Offset(0, 2),
-                ),
-              ],
+          borderRadius: BorderRadius.circular(6),
+          boxShadow: const [
+            BoxShadow(
+              color: Color(0x55000000),
+              blurRadius: 6,
+              offset: Offset(0, 2),
             ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-              child: Text(
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (icon != null) ...[
+                Icon(icon, size: 11, color: const Color(0xFFFFFFFF)),
+                const SizedBox(width: 4),
+              ],
+              Text(
                 label,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
@@ -404,7 +752,7 @@ class _EntryChipState extends State<_EntryChip> with TickerProviderStateMixin {
                   decoration: TextDecoration.none,
                 ),
               ),
-            ),
+            ],
           ),
         ),
       ),

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -29,8 +29,8 @@ class GhostOverlay {
   static final GlobalKey<_GhostOverlayState> _key = GlobalKey();
   static OverlayEntry? _entry;
 
-  /// The queue of (command, details) pairs waiting to be handed to the widget.
-  static final List<(String, String?)> _pending = [];
+  /// The queue of entries waiting to be handed to the widget.
+  static final List<_LogEntry> _pending = [];
 
   static bool _visible = true;
 
@@ -45,13 +45,32 @@ class GhostOverlay {
 
   /// Shows [command] (and optional [details]) in the command log overlay.
   ///
-  /// If the overlay is hidden (see [setVisible]) the entry is silently
-  /// ignored. If the overlay is not yet in the tree it is installed first;
-  /// any entries that arrive before the first build are queued and replayed
-  /// once the widget state is available.
-  static void log(String command, {String? details}) {
+  /// [kind] hints which icon to display: `"peek"`, `"poke"`, `"reload"`, or
+  /// `"screenshot"`. [finder] + [finderValue] identify a widget of interest
+  /// for visualizations. [viz] names an extra visual effect: `"flash"`,
+  /// `"outline"`, `"layout"`, or `"semantics"`.
+  ///
+  /// If the overlay is hidden (see [setVisible]) the call is silently ignored.
+  /// If the overlay is not yet in the tree it is installed first; any entries
+  /// that arrive before the first build are queued and replayed once the
+  /// widget state is available.
+  static void log(
+    String command, {
+    String? details,
+    String? kind,
+    String? finder,
+    String? finderValue,
+    String? viz,
+  }) {
     if (!_visible) return;
-    _pending.add((command, details));
+    _pending.add(_LogEntry(
+      command: command,
+      details: details,
+      kind: kind,
+      finder: finder,
+      finderValue: finderValue,
+      viz: viz,
+    ));
     _ensureInstalled();
   }
 
@@ -102,8 +121,8 @@ class GhostOverlay {
   static void _flushPending() {
     final state = _key.currentState;
     if (state == null || _pending.isEmpty) return;
-    for (final (command, details) in _pending) {
-      state.addEntry(command, details);
+    for (final entry in _pending) {
+      state.addEntry(entry);
     }
     _pending.clear();
   }
@@ -141,11 +160,30 @@ class _GhostOverlayWidget extends StatefulWidget {
 class _LogEntry {
   static int _nextId = 0;
 
-  _LogEntry({required this.command, this.details}) : id = _nextId++;
+  _LogEntry({
+    required this.command,
+    this.details,
+    this.kind,
+    this.finder,
+    this.finderValue,
+    this.viz,
+  }) : id = _nextId++;
 
   final int id;
   final String command;
   final String? details;
+
+  /// Icon category hint: `"peek"`, `"poke"`, `"reload"`, or `"screenshot"`.
+  final String? kind;
+
+  /// Finder type for the widget of interest (same values as `perform_action`).
+  final String? finder;
+
+  /// Finder value for the widget of interest.
+  final String? finderValue;
+
+  /// Extra visualization: `"flash"`, `"outline"`, `"layout"`, or `"semantics"`.
+  final String? viz;
 }
 
 class _GhostOverlayState extends State<_GhostOverlayWidget> {
@@ -173,9 +211,8 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
     });
   }
 
-  void addEntry(String command, String? details) {
+  void addEntry(_LogEntry entry) {
     if (!mounted) return;
-    final entry = _LogEntry(command: command, details: details);
     final key = GlobalKey<_EntryChipState>();
     setState(() {
       if (_entries.length >= GhostOverlay._maxEntries) {

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -29,7 +29,7 @@ class GhostOverlay {
 
   static const Duration _chipDuration = Duration(seconds: 3);
   static const Duration _semanticsDuration = Duration(seconds: 3);
-  static const Duration _outlineDuration = Duration(milliseconds: 900);
+  static const Duration _outlineDuration = Duration(milliseconds: 750);
 
   static final GlobalKey<_GhostOverlayState> _key = GlobalKey();
   static OverlayEntry? _entry;
@@ -247,9 +247,12 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
     }
 
     if (entry.viz == 'flash') setState(() => _flashCount++);
-    if (entry.viz == 'outline' &&
+    if ((entry.viz == 'outline' || entry.viz == 'layout') &&
         entry.finder != null &&
         entry.finderValue != null) {
+      // TODO: 'layout' could get a specialized visualization (padding overlays,
+      // flex annotations, etc.) once ext.slipstream.inspect_layout is
+      // implemented with in-process finder support.
       _triggerOutline(entry.finder!, entry.finderValue!);
     }
     if (entry.viz == 'semantics') _triggerSemantics();

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+
+// ---------------------------------------------------------------------------
+// Public API
+
+/// Displays a transient command log above the app's widget tree.
+///
+/// Call [log] to add an entry. The overlay locates the first [OverlayState]
+/// in the widget tree and inserts itself lazily — no app-side setup is
+/// required beyond calling [SlipstreamAgent.init].
+///
+/// Each entry is shown for [_displayDuration] and then removed. When the
+/// overlay has been removed from the tree (e.g. after a hot restart), it
+/// reinstalls itself on the next [log] call.
+class GhostOverlay {
+  GhostOverlay._();
+
+  static const Duration _displayDuration = Duration(seconds: 3);
+  static const int _maxEntries = 5;
+
+  static final GlobalKey<_GhostOverlayState> _key = GlobalKey();
+  static OverlayEntry? _entry;
+
+  /// The queue of (command, details) pairs waiting to be handed to the widget.
+  static final List<(String, String?)> _pending = [];
+
+  /// Shows [command] (and optional [details]) in the command log overlay.
+  ///
+  /// If the overlay is not yet in the tree it is installed first; any entries
+  /// that arrive before the first build are queued and replayed once the
+  /// widget state is available.
+  static void log(String command, {String? details}) {
+    _pending.add((command, details));
+    _ensureInstalled();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Installation
+
+  static void _ensureInstalled() {
+    if (_entry != null && _entry!.mounted) {
+      _flushPending();
+      return;
+    }
+
+    final overlay = _findOverlay();
+    if (overlay == null) {
+      // Widget tree not ready yet — retry after the next frame.
+      WidgetsBinding.instance.addPostFrameCallback((_) => _ensureInstalled());
+      return;
+    }
+
+    _entry = OverlayEntry(builder: (_) => _GhostOverlayWidget(key: _key));
+    overlay.insert(_entry!);
+
+    // The widget state is not built until the next frame.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _flushPending());
+  }
+
+  static void _flushPending() {
+    final state = _key.currentState;
+    if (state == null || _pending.isEmpty) return;
+    for (final (command, details) in _pending) {
+      state.addEntry(command, details);
+    }
+    _pending.clear();
+  }
+
+  static OverlayState? _findOverlay() {
+    OverlayState? result;
+    void visit(Element element) {
+      if (result != null) return;
+      if (element is StatefulElement && element.state is OverlayState) {
+        result = element.state as OverlayState;
+        return;
+      }
+      element.visitChildren(visit);
+    }
+    WidgetsBinding.instance.rootElement?.visitChildren(visit);
+    return result;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Widget
+
+class _GhostOverlayWidget extends StatefulWidget {
+  const _GhostOverlayWidget({super.key});
+
+  @override
+  State<_GhostOverlayWidget> createState() => _GhostOverlayState();
+}
+
+class _LogEntry {
+  _LogEntry({required this.command, this.details}) : id = _nextId++;
+  static int _nextId = 0;
+  final int id;
+  final String command;
+  final String? details;
+}
+
+class _GhostOverlayState extends State<_GhostOverlayWidget> {
+  final List<_LogEntry> _entries = [];
+  final List<Timer> _timers = [];
+
+  void addEntry(String command, String? details) {
+    if (!mounted) return;
+    final entry = _LogEntry(command: command, details: details);
+    setState(() {
+      _entries.add(entry);
+      if (_entries.length > GhostOverlay._maxEntries) {
+        _entries.removeAt(0);
+      }
+    });
+    _timers.add(Timer(GhostOverlay._displayDuration, () {
+      if (!mounted) return;
+      setState(() => _entries.removeWhere((e) => e.id == entry.id));
+    }));
+  }
+
+  @override
+  void dispose() {
+    for (final t in _timers) {
+      t.cancel();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_entries.isEmpty) return const SizedBox.shrink();
+
+    // OverlayEntry builds inside the Overlay's Stack, so Positioned works
+    // directly here. Use MediaQuery for safe-area insets when available.
+    final bottomInset = MediaQuery.maybePaddingOf(context)?.bottom ?? 0.0;
+
+    return Positioned(
+      bottom: bottomInset + 12,
+      right: 12,
+      child: IgnorePointer(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            for (final entry in _entries) _EntryChip(entry: entry),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EntryChip extends StatelessWidget {
+  const _EntryChip({required this.entry});
+
+  final _LogEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = entry.details != null
+        ? '${entry.command}: ${entry.details}'
+        : entry.command;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          // Slipstream blue, semi-opaque so the app beneath remains visible.
+          color: const Color(0xE01565C0),
+          borderRadius: BorderRadius.circular(14),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          child: Text(
+            label,
+            style: const TextStyle(
+              color: Color(0xFFFFFFFF),
+              fontSize: 13,
+              fontWeight: FontWeight.normal,
+              decoration: TextDecoration.none,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/slipstream_agent/lib/src/overlays.dart
+++ b/slipstream_agent/lib/src/overlays.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/widgets.dart';
 
+import 'ghost_overlay.dart';
+
 /// Manages visibility of Flutter and Slipstream overlays.
 ///
 /// Call with `false` to hide all overlays and save their current state.
@@ -36,6 +38,8 @@ void _save() {
 
 void _hideAll() {
   WidgetsApp.debugAllowBannerOverride = false;
+  GhostOverlay.overlayEnabled = false;
+  GhostOverlay.clearEntries();
 }
 
 void _restore() {
@@ -43,6 +47,7 @@ void _restore() {
     WidgetsApp.debugAllowBannerOverride = _savedDebugBanner!;
     _savedDebugBanner = null;
   }
+  GhostOverlay.overlayEnabled = true;
 }
 
 // ---------------------------------------------------------------------------

--- a/slipstream_agent/lib/src/overlays.dart
+++ b/slipstream_agent/lib/src/overlays.dart
@@ -2,22 +2,20 @@ import 'package:flutter/widgets.dart';
 
 import 'ghost_overlay.dart';
 
-/// Manages visibility of Flutter and Slipstream overlays.
+/// Manages visibility of Slipstream overlays.
 ///
-/// Call with `false` to hide all overlays and save their current state.
-/// Call with `true` to restore the previously saved state. If called with
-/// `true` before any `false` call, it is a no-op.
+/// Call with `false` to hide all Slipstream overlays (the banner and command
+/// log chips) before taking a screenshot. Call with `true` to restore them.
+///
+/// The Flutter debug banner is permanently disabled when the ghost overlay is
+/// installed (on the first [ext.slipstream.ping] or [ext.slipstream.log]
+/// call), and is not restored here.
 ///
 /// Marks the widget tree dirty and schedules a frame, but does not await the
 /// frame. Callers that need the change to be painted before proceeding (e.g.
 /// before taking a screenshot) should wait for the next frame themselves.
 void setOverlaysEnabled(bool enabled) {
-  if (enabled) {
-    _restore();
-  } else {
-    _save();
-    _hideAll();
-  }
+  GhostOverlay.setVisible(enabled);
 
   // Mark the tree dirty so the overlay change takes effect on the next frame.
   final root = WidgetsBinding.instance.rootElement;
@@ -25,29 +23,6 @@ void setOverlaysEnabled(bool enabled) {
     _markNeedsRebuild(root);
   }
   WidgetsBinding.instance.scheduleFrame();
-}
-
-// ---------------------------------------------------------------------------
-// Saved state
-
-bool? _savedDebugBanner;
-
-void _save() {
-  _savedDebugBanner = WidgetsApp.debugAllowBannerOverride;
-}
-
-void _hideAll() {
-  WidgetsApp.debugAllowBannerOverride = false;
-  GhostOverlay.overlayEnabled = false;
-  GhostOverlay.clearEntries();
-}
-
-void _restore() {
-  if (_savedDebugBanner != null) {
-    WidgetsApp.debugAllowBannerOverride = _savedDebugBanner!;
-    _savedDebugBanner = null;
-  }
-  GhostOverlay.overlayEnabled = true;
 }
 
 // ---------------------------------------------------------------------------

--- a/slipstream_agent/lib/src/semantics.dart
+++ b/slipstream_agent/lib/src/semantics.dart
@@ -70,9 +70,11 @@ class SemanticsNodeInfo {
 /// Returns a flat list of visible semantics nodes with screen-space bounds,
 /// plus an error string if the tree is unavailable.
 ///
-/// Unlike the out-of-process implementation, [SemanticsNodeInfo.screenRect]
-/// values are accumulated screen-space coordinates in logical pixels (not each
-/// node's unreliable local coordinate space).
+/// [SemanticsNodeInfo.screenRect] values are in logical screen pixels.
+/// Positions are obtained via [RenderBox.localToGlobal], which stays in logical
+/// pixel space by not including the [RenderView]'s device-pixel-ratio scale.
+/// This matches the coordinate system used by [Positioned.fromRect] in the
+/// overlay.
 ///
 /// Callers should invoke `ext.slipstream.enable_semantics` and wait for a
 /// frame before calling this if the tree may not yet be enabled.
@@ -90,11 +92,19 @@ class SemanticsNodeInfo {
     return (null, 'semantics tree empty — retry after a frame renders');
   }
 
+  // Walk the render tree rather than the semantics tree so we can use
+  // RenderBox.localToGlobal for positions. Semantics transforms are in
+  // physical pixels (RenderView._rootTransform scales by devicePixelRatio),
+  // but localToGlobal excludes RenderView and stays in logical pixels.
   final entries = <_Entry>[];
-  _collect(root, Matrix4.identity(), entries);
+  final seenIds = <int>{};
+  for (final renderView in RendererBinding.instance.renderViews) {
+    _collectFromRenderTree(renderView, entries, seenIds);
+  }
 
   final nodes =
       entries.where(_hasContent).map(_toNodeInfo).toList(growable: false);
+
   return (nodes, null);
 }
 
@@ -111,36 +121,34 @@ class _Entry {
   _Entry(this.node, this.data, this.screenRect);
 }
 
-/// Recursively collects [SemanticsNode]s, skipping hidden and invisible ones.
+/// Recursively walks the render tree collecting [SemanticsNode]s.
 ///
-/// [localToScreen] is the cumulative transform from the current node's local
-/// coordinate space to screen space. Pass [Matrix4.identity] for the root.
-void _collect(
-  SemanticsNode node,
-  Matrix4 localToScreen,
+/// Uses [RenderBox.localToGlobal] for screen-space positions so that
+/// coordinates stay in logical pixels, matching the overlay's coordinate
+/// system. [seenIds] prevents duplicates when multiple render objects share
+/// the same semantics node (e.g. sibling-merged nodes).
+void _collectFromRenderTree(
+  RenderObject renderObject,
   List<_Entry> out,
+  Set<int> seenIds,
 ) {
-  if (node.isInvisible) return;
+  final semanticsNode = renderObject.debugSemantics;
 
-  final data = node.getSemanticsData();
-  if (data.flagsCollection.isHidden) return;
-
-  // node.transform maps FROM this node's local space TO the parent's space.
-  // Composing: childLocalToScreen = parentLocalToScreen * childTransform
-  final nodeTransform = node.transform;
-  final Matrix4 childLocalToScreen = nodeTransform != null
-      ? (localToScreen.clone()..multiply(nodeTransform))
-      : localToScreen;
-
-  out.add(_Entry(
-      node, data, MatrixUtils.transformRect(childLocalToScreen, node.rect)));
-
-  if (!node.mergeAllDescendantsIntoThisNode) {
-    node.visitChildren((child) {
-      _collect(child, childLocalToScreen, out);
-      return true;
-    });
+  if (semanticsNode != null &&
+      !semanticsNode.isMergedIntoParent &&
+      !semanticsNode.isInvisible &&
+      seenIds.add(semanticsNode.id)) {
+    final data = semanticsNode.getSemanticsData();
+    if (!data.flagsCollection.isHidden && renderObject is RenderBox) {
+      final offset = renderObject.localToGlobal(Offset.zero);
+      final screenRect = offset & renderObject.semanticBounds.size;
+      out.add(_Entry(semanticsNode, data, screenRect));
+    }
   }
+
+  renderObject.visitChildrenForSemantics((child) {
+    _collectFromRenderTree(child, out, seenIds);
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/slipstream_agent/lib/src/semantics.dart
+++ b/slipstream_agent/lib/src/semantics.dart
@@ -2,12 +2,75 @@ import 'dart:ui' show CheckedState, Tristate;
 
 import 'package:flutter/rendering.dart';
 
-/// Returns a flat list of visible semantics nodes as JSON-serializable maps,
+// ---------------------------------------------------------------------------
+// Public API
+
+/// A visible semantics node with screen-space bounds.
+///
+/// Fields mirror `SemanticNode` in `flutter_slipstream` so callers can
+/// serialise with [toMap] and reconstruct that type on the server side.
+class SemanticsNodeInfo {
+  const SemanticsNodeInfo({
+    required this.id,
+    required this.role,
+    required this.label,
+    required this.value,
+    required this.hint,
+    required this.checked,
+    required this.toggled,
+    required this.selected,
+    required this.enabled,
+    required this.focused,
+    required this.actions,
+    required this.screenRect,
+  });
+
+  final int id;
+
+  /// `"button"`, `"textfield"`, `"slider"`, `"link"`, `"image"`, `"header"`,
+  /// `"checkbox"`, `"toggle"`, or `"radio"`.
+  final String? role;
+
+  final String label;
+  final String value;
+  final String hint;
+  final bool? checked;
+  final bool? toggled;
+  final bool? selected;
+  final bool? enabled;
+  final bool focused;
+
+  /// [SemanticsAction] bitmask.
+  final int actions;
+
+  /// Bounding rectangle in logical screen coordinates.
+  final Rect screenRect;
+
+  /// Returns a JSON-serializable map with the same field names as
+  /// `SemanticNode` in `flutter_slipstream`.
+  Map<String, Object?> toMap() => {
+        'id': id,
+        if (role != null) 'role': role,
+        'label': label,
+        'value': value,
+        'hint': hint,
+        if (checked != null) 'checked': checked,
+        if (toggled != null) 'toggled': toggled,
+        if (selected != null) 'selected': selected,
+        if (enabled != null) 'enabled': enabled,
+        'focused': focused,
+        'actions': actions,
+        'left': screenRect.left,
+        'top': screenRect.top,
+        'right': screenRect.right,
+        'bottom': screenRect.bottom,
+      };
+}
+
+/// Returns a flat list of visible semantics nodes with screen-space bounds,
 /// plus an error string if the tree is unavailable.
 ///
-/// Each map has the same fields as `SemanticNode` in the flutter_slipstream
-/// package, so callers can deserialize directly into that type. Unlike the
-/// out-of-process implementation, the [left] / [top] / [right] / [bottom]
+/// Unlike the out-of-process implementation, [SemanticsNodeInfo.screenRect]
 /// values are accumulated screen-space coordinates in logical pixels (not each
 /// node's unreliable local coordinate space).
 ///
@@ -16,7 +79,7 @@ import 'package:flutter/rendering.dart';
 ///
 /// Returns `(null, errorMessage)` if semantics is not enabled or the tree is
 /// empty.
-(List<Map<String, Object?>>?, String?) getSemanticsNodes() {
+(List<SemanticsNodeInfo>?, String?) getSemanticsNodes() {
   // TODO: Investigate how to move over to use rootPipelineOwner or
   // SemanticsBinding without losing the semantics tree.
   // ignore: deprecated_member_use
@@ -30,7 +93,8 @@ import 'package:flutter/rendering.dart';
   final entries = <_Entry>[];
   _collect(root, Matrix4.identity(), entries);
 
-  final nodes = entries.where(_hasContent).map(_toMap).toList(growable: false);
+  final nodes =
+      entries.where(_hasContent).map(_toNodeInfo).toList(growable: false);
   return (nodes, null);
 }
 
@@ -38,12 +102,13 @@ import 'package:flutter/rendering.dart';
 // Tree traversal
 
 class _Entry {
-  _Entry(this.node, this.data, this.screenRect);
   final SemanticsNode node;
   final SemanticsData data;
 
   /// Bounding rectangle in logical screen coordinates.
   final Rect screenRect;
+
+  _Entry(this.node, this.data, this.screenRect);
 }
 
 /// Recursively collects [SemanticsNode]s, skipping hidden and invisible ones.
@@ -79,69 +144,63 @@ void _collect(
 }
 
 // ---------------------------------------------------------------------------
-// Node → map
+// Entry → SemanticsNodeInfo
 
-/// Converts an [_Entry] to a JSON-serializable map with the same field names
-/// as `SemanticNode` in flutter_slipstream.
-Map<String, Object?> _toMap(_Entry e) {
-  final d = e.data;
-  final f = d.flagsCollection;
+SemanticsNodeInfo _toNodeInfo(_Entry entry) {
+  final flags = entry.data.flagsCollection;
 
-  final bool? checked = f.isChecked == CheckedState.none
-      ? null
-      : f.isChecked == CheckedState.isTrue;
-  final bool? toggled =
-      f.isToggled == Tristate.none ? null : f.isToggled == Tristate.isTrue;
-  final bool? selected =
-      f.isSelected == Tristate.none ? null : f.isSelected == Tristate.isTrue;
-  final bool? enabled =
-      f.isEnabled == Tristate.none ? null : f.isEnabled == Tristate.isTrue;
-  final bool focused = f.isFocused == Tristate.isTrue;
-
-  return {
-    'id': e.node.id,
-    'role': _role(f),
-    'label': d.label,
-    'value': d.value,
-    'hint': d.hint,
-    'checked': checked,
-    'toggled': toggled,
-    'selected': selected,
-    'enabled': enabled,
-    'focused': focused,
-    'actions': d.actions,
-    'left': e.screenRect.left,
-    'top': e.screenRect.top,
-    'right': e.screenRect.right,
-    'bottom': e.screenRect.bottom,
-  };
+  return SemanticsNodeInfo(
+    id: entry.node.id,
+    role: _role(flags),
+    label: entry.data.label,
+    value: entry.data.value,
+    hint: entry.data.hint,
+    checked: flags.isChecked == CheckedState.none
+        ? null
+        : flags.isChecked == CheckedState.isTrue,
+    toggled: flags.isToggled == Tristate.none
+        ? null
+        : flags.isToggled == Tristate.isTrue,
+    selected: flags.isSelected == Tristate.none
+        ? null
+        : flags.isSelected == Tristate.isTrue,
+    enabled: flags.isEnabled == Tristate.none
+        ? null
+        : flags.isEnabled == Tristate.isTrue,
+    focused: flags.isFocused == Tristate.isTrue,
+    actions: entry.data.actions,
+    screenRect: entry.screenRect,
+  );
 }
 
 // ---------------------------------------------------------------------------
 // Helpers
 
-String _role(SemanticsFlags f) {
-  if (f.isButton) return 'button';
-  if (f.isTextField) return 'textfield';
-  if (f.isSlider) return 'slider';
-  if (f.isLink) return 'link';
-  if (f.isImage) return 'image';
-  if (f.isHeader) return 'header';
-  if (f.isChecked != CheckedState.none) return 'checkbox';
-  if (f.isToggled != Tristate.none) return 'toggle';
-  if (f.isInMutuallyExclusiveGroup) return 'radio';
-  return '';
+String? _role(SemanticsFlags flags) {
+  if (flags.isButton) return 'button';
+  if (flags.isTextField) return 'textfield';
+  if (flags.isSlider) return 'slider';
+  if (flags.isLink) return 'link';
+  if (flags.isImage) return 'image';
+  if (flags.isHeader) return 'header';
+  if (flags.isChecked != CheckedState.none) return 'checkbox';
+  if (flags.isToggled != Tristate.none) return 'toggle';
+  if (flags.isInMutuallyExclusiveGroup) return 'radio';
+
+  return null;
 }
 
-bool _hasContent(_Entry e) {
-  final d = e.data;
+bool _hasContent(_Entry entry) {
+  final d = entry.data;
   final f = d.flagsCollection;
+
   if (f.isChecked != CheckedState.none) return true;
   if (f.isToggled != Tristate.none) return true;
   if (f.isSelected == Tristate.isTrue) return true;
   if (f.isEnabled == Tristate.isFalse) return true;
   if (f.isFocused == Tristate.isTrue) return true;
   if (d.actions != 0) return true;
-  if (_role(f).isNotEmpty) return true;
+  if (_role(f) != null) return true;
+
   return d.label.isNotEmpty || d.value.isNotEmpty || d.hint.isNotEmpty;
 }

--- a/slipstream_agent/lib/src/version.dart
+++ b/slipstream_agent/lib/src/version.dart
@@ -1,4 +1,2 @@
 // Keep this version in-sync with pubspec.yaml.
-
-/// package:slipstream_agent version.
-const String packageVersion = '1.0.0';
+const String packageVersion = '1.1.0-wip';

--- a/slipstream_agent/lib/src/version.dart
+++ b/slipstream_agent/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Keep this version in-sync with pubspec.yaml.
-const String packageVersion = '1.1.0-wip';
+const String packageVersion = '1.1.0';

--- a/slipstream_agent/pubspec.yaml
+++ b/slipstream_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: slipstream_agent
 # Keep this version in-sync with lib/src/version.dart.
-version: 1.1.0-wip
+version: 1.1.0
 description: An in-process companion for the Flutter Slipstream agent tools.
 
 repository: https://github.com/devoncarew/slipstream_agent/tree/main/slipstream_agent

--- a/slipstream_agent/pubspec.yaml
+++ b/slipstream_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: slipstream_agent
 # Keep this version in-sync with lib/src/version.dart.
-version: 1.0.0
+version: 1.1.0-wip
 description: An in-process companion for the Flutter Slipstream agent tools.
 
 repository: https://github.com/devoncarew/slipstream_agent/tree/main/slipstream_agent

--- a/slipstream_agent/test/slipstream_agent_test.dart
+++ b/slipstream_agent/test/slipstream_agent_test.dart
@@ -396,15 +396,12 @@ void main() {
       expect(nodes!.isNotEmpty, isTrue);
 
       for (final node in nodes) {
-        expect(node, contains('id'));
-        expect(node, contains('role'));
-        expect(node, contains('label'));
-        expect(node, contains('value'));
-        expect(node, contains('hint'));
-        expect(node, contains('left'));
-        expect(node, contains('top'));
-        expect(node, contains('right'));
-        expect(node, contains('bottom'));
+        expect(node.id, isNot(equals(0)));
+        expect(node.role, isNotNull);
+        expect(node.label, isNotEmpty);
+        expect(node.value, isNotNull);
+        expect(node.hint, isNotNull);
+        expect(node.screenRect, isNot(isEmpty));
       }
     });
 
@@ -427,7 +424,7 @@ void main() {
       handle.dispose();
 
       expect(nodes, isNotNull);
-      final buttonNodes = nodes!.where((n) => n['role'] == 'button').toList();
+      final buttonNodes = nodes!.where((n) => n.role == 'button').toList();
       expect(buttonNodes, isNotEmpty);
     });
 
@@ -448,7 +445,7 @@ void main() {
 
       expect(nodes, isNotNull);
       final textFieldNodes =
-          nodes!.where((n) => n['role'] == 'textfield').toList();
+          nodes!.where((n) => n.role == 'textfield').toList();
       expect(textFieldNodes, isNotEmpty);
     });
 
@@ -472,14 +469,14 @@ void main() {
 
       expect(nodes, isNotNull);
 
-      final buttonNodes = nodes!.where((n) => n['role'] == 'button').toList();
+      final buttonNodes = nodes!.where((n) => n.role == 'button').toList();
       expect(buttonNodes, isNotEmpty);
 
-      final btn = buttonNodes.first;
-      final left = btn['left'] as double;
-      final top = btn['top'] as double;
-      final right = btn['right'] as double;
-      final bottom = btn['bottom'] as double;
+      final dimensions = buttonNodes.first.screenRect;
+      final left = dimensions.left;
+      final top = dimensions.top;
+      final right = dimensions.right;
+      final bottom = dimensions.bottom;
 
       expect(right - left, greaterThan(0));
       expect(bottom - top, greaterThan(0));

--- a/slipstream_agent/test/slipstream_agent_test.dart
+++ b/slipstream_agent/test/slipstream_agent_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:slipstream_agent/slipstream_agent.dart';
 import 'package:slipstream_agent/src/actions.dart';
 import 'package:slipstream_agent/src/finder.dart';
+import 'package:slipstream_agent/src/ghost_overlay.dart';
 import 'package:slipstream_agent/src/overlays.dart';
 import 'package:slipstream_agent/src/semantics.dart';
 
@@ -487,59 +488,45 @@ void main() {
 
   group('setOverlaysEnabled', () {
     setUp(() {
-      // Ensure the banner override is in its default state before each test.
-      WidgetsApp.debugAllowBannerOverride = true;
+      // Reset GhostOverlay visibility before each test.
+      GhostOverlay.setVisible(true);
     });
 
-    testWidgets('hides the debug banner when called with false',
+    testWidgets('hides the ghost overlay when called with false',
         (tester) async {
+      // pumpWidget installs the OverlayEntry (via post-frame callback).
+      // First pump builds the widget and schedules _flushPending.
+      // Second pump rebuilds with the chip visible.
+      GhostOverlay.log('hello');
       await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+      await tester.pump();
+      await tester.pump();
 
-      expect(WidgetsApp.debugAllowBannerOverride, isTrue);
+      expect(find.text('hello'), findsOneWidget);
 
       setOverlaysEnabled(false);
       await tester.pump();
 
-      expect(WidgetsApp.debugAllowBannerOverride, isFalse);
+      expect(find.text('hello'), findsNothing);
     });
 
-    testWidgets('restores the debug banner when called with true',
+    testWidgets('restores the ghost overlay when called with true',
         (tester) async {
+      // Install the overlay first.
+      GhostOverlay.log('setup');
       await tester.pumpWidget(const MaterialApp(home: Scaffold()));
-
-      setOverlaysEnabled(false);
       await tester.pump();
-      expect(WidgetsApp.debugAllowBannerOverride, isFalse);
-
-      setOverlaysEnabled(true);
       await tester.pump();
-      expect(WidgetsApp.debugAllowBannerOverride, isTrue);
-    });
-
-    testWidgets('restores to false if banner was already hidden',
-        (tester) async {
-      WidgetsApp.debugAllowBannerOverride = false;
-      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
 
       setOverlaysEnabled(false);
       await tester.pump();
 
       setOverlaysEnabled(true);
+      // Entry is already mounted — log goes directly to the state.
+      GhostOverlay.log('world');
       await tester.pump();
 
-      // Restored to the state it was in before the hide call.
-      expect(WidgetsApp.debugAllowBannerOverride, isFalse);
-    });
-
-    testWidgets('restore is a no-op when no prior hide was called',
-        (tester) async {
-      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
-
-      // No hide call made — restore should leave the banner enabled.
-      setOverlaysEnabled(true);
-      await tester.pump();
-
-      expect(WidgetsApp.debugAllowBannerOverride, isTrue);
+      expect(find.text('world'), findsOneWidget);
     });
   });
 }

--- a/slipstream_showcase/.gitignore
+++ b/slipstream_showcase/.gitignore
@@ -28,5 +28,3 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
-
-.gemini/


### PR DESCRIPTION
Implements the ghost overlay command log and associated visualizations for the 1.1.0 release.

- Adds `ext.slipstream.log` extension with `kind`, `finder`, `finderValue`, and `viz` parameters; in-process extensions log automatically
- Adds ghost overlay: animated chip at the bottom of the app showing recent agent actions, and a "slipstream" banner replacing the Flutter debug banner
- Adds `viz` visualizations: `"flash"` (full-screen tint), `"outline"` (animated bounding-box highlight), `"semantics"` (outlines on all visible semantics nodes), `"layout"` (falls back to `"outline"` for now)
- Fixes `ext.slipstream.get_semantics` screen-space coordinates by switching from semantics transform accumulation (physical pixels) to `RenderBox.localToGlobal` (logical pixels); uses `visitChildrenForSemantics` to exclude inactive widgets (e.g. off-screen `IndexedStack` tabs)
- Bumps version to 1.1.0
- closes https://github.com/devoncarew/slipstream_agent/issues/9
