### PR TITLE
fix ghost overlay not appearing in MaterialApp.router apps (1.1.1)

### DIFF
--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,11 +1,18 @@
-## 1.1.1-wip
+## 1.1.1
 
+- Fix ghost overlay not appearing in apps that use `MaterialApp.router` (e.g.
+  GoRouter with `ShellRoute`). In current Flutter, `OverlayEntry.mounted` only
+  becomes `true` after the widget builds on the next frame, not immediately
+  after `overlay.insert()`. The fix tracks the target `OverlayState` and skips
+  re-insertion when the entry is pending its first build on the same overlay.
+- Addressed an intermittent error after a hot restart; "Multiple widgets used
+  the same GlobalKey".
 - Fix `bySemanticsLabel` finder missing widgets whose semantics label comes from
-  an implicit source (e.g. `ElevatedButton` merging its child text,
-  `TextField` mapping `InputDecoration.labelText`, `Semantics.attributedLabel`).
-  The finder now falls back to the render-level semantics node — the same data
-  source as `ext.slipstream.get_semantics` — so the label an agent sees in
-  `get_semantics` output can always be used to target that widget.
+  an implicit source (e.g. `ElevatedButton` merging its child text, `TextField`
+  mapping `InputDecoration.labelText`, `Semantics.attributedLabel`). The finder
+  now falls back to the render-level semantics node — the same data source as
+  `ext.slipstream.get_semantics` — so the label an agent sees in `get_semantics`
+  output can always be used to target that widget.
 
 ## 1.1.0
 

--- a/slipstream_agent/docs/notes.md
+++ b/slipstream_agent/docs/notes.md
@@ -18,3 +18,8 @@ Visualizations:
 | `get_semantics`                | (read) "get semantics" semantics bounding boxes        |
 | `perform_semantic_action`      | (interact) "perform semantic: action id" bounding box? |
 | `close_app`                    | -                                                      |
+
+## Other
+
+- [ ] we have a use case for a general x,y tap - dismissing a dialog, ...; or
+      perhaps a 'dismiss dialog' semantic action, ...

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -34,6 +34,12 @@ class GhostOverlay {
   static final GlobalKey<_GhostOverlayState> _key = GlobalKey();
   static OverlayEntry? _entry;
 
+  /// The [OverlayState] that [_entry] was inserted into. Used to distinguish
+  /// "entry inserted but widget not yet built on this overlay" from "widget
+  /// torn down and a new overlay was created" — the latter requires
+  /// re-insertion even though [_entry] is non-null.
+  static OverlayState? _targetOverlay;
+
   /// The queue of entries waiting to be handed to the widget.
   static final List<_LogMessage> _pending = [];
 
@@ -113,9 +119,18 @@ class GhostOverlay {
       return;
     }
 
-    // Permanently disable the Flutter debug banner for this session.
+    if (_entry != null && overlay == _targetOverlay) {
+      // Entry was inserted into this overlay but the widget hasn't built yet
+      // (OverlayEntry.mounted is only true after the first build). Don't
+      // insert a second entry — that would produce a GlobalKey conflict.
+      return;
+    }
+
+    // New overlay (first install or widget tree was rebuilt after a hot
+    // restart / test teardown).
     WidgetsApp.debugAllowBannerOverride = false;
 
+    _targetOverlay = overlay;
     _entry = OverlayEntry(builder: (_) => _GhostOverlayWidget(key: _key));
     overlay.insert(_entry!);
 
@@ -133,6 +148,12 @@ class GhostOverlay {
   }
 
   static OverlayState? _findOverlay() {
+    final rootElement = WidgetsBinding.instance.rootElement;
+    if (rootElement == null) return null;
+
+    // Walk the element tree depth-first.  The first OverlayState encountered
+    // is the outermost one (closest to the root) — exactly where we want to
+    // insert so the overlay paints above all app content.
     OverlayState? result;
     void visit(Element element) {
       if (result != null) return;
@@ -143,7 +164,26 @@ class GhostOverlay {
       element.visitChildren(visit);
     }
 
-    WidgetsBinding.instance.rootElement?.visitChildren(visit);
+    rootElement.visitChildren(visit);
+
+    // Fallback: walk to the deepest leaf element and ask Flutter's own
+    // `Overlay.maybeOf()` to walk back up to the nearest Overlay ancestor. This
+    // handles unusual configurations where the DFS ordering could pick the
+    // wrong Overlay (e.g. a deeply-nested Navigator appearing earlier in the
+    // visit order).
+    if (result == null) {
+      Element? leaf;
+      void findLeaf(Element element) {
+        leaf = element;
+        element.visitChildren(findLeaf);
+      }
+
+      rootElement.visitChildren(findLeaf);
+      if (leaf != null) {
+        result = Overlay.maybeOf(leaf!);
+      }
+    }
+
     return result;
   }
 }
@@ -339,6 +379,13 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
 
     return IgnorePointer(
       child: Stack(
+        // StackFit.expand ensures the Stack fills the Overlay's area even when
+        // the Overlay passes loose rather than tight constraints.  Without it,
+        // the Stack would shrink-wrap its non-positioned children
+        // (_FlashOverlay / _OutlineOverlay / _SemanticsOverlay all return
+        // SizedBox.shrink() when idle), collapsing to 0×0 and hiding the
+        // Positioned.fill banner.
+        fit: StackFit.expand,
         children: [
           // Brief white full-screen tint for viz:"flash" entries.
           _FlashOverlay(triggerCount: _flashCount),

--- a/slipstream_agent/lib/src/version.dart
+++ b/slipstream_agent/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Keep this version in-sync with pubspec.yaml.
-const String packageVersion = '1.1.1-wip';
+const String packageVersion = '1.1.1';

--- a/slipstream_agent/pubspec.yaml
+++ b/slipstream_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: slipstream_agent
 # Keep this version in-sync with lib/src/version.dart.
-version: 1.1.1-wip
+version: 1.1.1
 description: An in-process companion for the Flutter Slipstream agent tools.
 
 repository: https://github.com/devoncarew/slipstream_agent/tree/main/slipstream_agent


### PR DESCRIPTION
Fix ghost overlay (banner + chips) never appearing in apps that use `MaterialApp.router` with GoRouter/ShellRoute.

- In current Flutter, `OverlayEntry.mounted` only becomes `true` after the widget builds on the next frame, not immediately after `overlay.insert()`. The previous guard fell through on every `log()` call during that window, inserting duplicate entries that all shared the same `GlobalKey` — the conflict prevented any of them from rendering. The fix tracks the target `OverlayState` and skips re-insertion when the entry is already pending its first build on the same overlay. Re-insertion is still triggered when the overlay itself is replaced (hot restart, test teardown).
- Fix `bySemanticsLabel` for implicit semantics (ElevatedButton, TextField `labelText`, `Semantics.attributedLabel`) by falling back to the render-level semantics node.
- Bump to 1.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)