### PR TITLE
1.2.0: settle, error banner, byTextContaining, ghost_overlay refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,6 @@ with `streamListen('Extension')` and filter by `event.extensionKind`.
 
 | Event                          | Trigger                        | Source                                                    |
 | ------------------------------ | ------------------------------ | --------------------------------------------------------- |
-| `ext.slipstream.windowResized` | Window/display metrics change  | `WidgetsBindingObserver.didChangeMetrics`                 |
 | `ext.slipstream.routeChanged`  | Router navigates to a new path | `GoRouterAdapter` listener on the `GoRouter` `Listenable` |
 
 Telemetry is initialized automatically by `Agent.initialize()` via

--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -5,7 +5,7 @@
   transitions time to complete before the next tool call.
 - Add a persistent error banner: `FlutterError.onError` is intercepted and
   surfaces errors as a red chip near the top of the screen showing a running
-  count and a brief summary, e.g. `(3) flutter.error: Null check operator…`. The
+  count and a brief summary, e.g. `flutter.error: Null check operator…`. The
   banner is visible in agent screenshots and clears automatically on hot reload
   or via the new `ext.slipstream.clear_errors` extension.
 - Add `ext.slipstream.clear_errors` extension: dismisses the error banner (call

--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -3,6 +3,13 @@
 - `ext.slipstream.perform_action` and `ext.slipstream.navigate` now wait for
   the widget tree to settle before returning, giving animations and navigation
   transitions time to complete before the next tool call.
+- Add a persistent error banner: `FlutterError.onError` is intercepted and
+  surfaces errors as a red chip near the top of the screen showing a running
+  count and a brief summary, e.g. `(3) flutter.error: Null check operator…`.
+  The banner is visible in agent screenshots and clears automatically on hot
+  reload or via the new `ext.slipstream.clear_errors` extension.
+- Add `ext.slipstream.clear_errors` extension: dismisses the error banner (call
+  after `get_output` or whenever the agent has acknowledged the errors).
 - Add `byTextContaining` finder: matches a `Text` widget whose content contains
   the given value as a substring. Useful when displayed text is truncated (e.g.
   `"Lorem ipsum..."` vs the full string).

--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -3,6 +3,9 @@
 - `ext.slipstream.perform_action` and `ext.slipstream.navigate` now wait for
   the widget tree to settle before returning, giving animations and navigation
   transitions time to complete before the next tool call.
+- Add `byTextContaining` finder: matches a `Text` widget whose content contains
+  the given value as a substring. Useful when displayed text is truncated (e.g.
+  `"Lorem ipsum..."` vs the full string).
 - Remove the `ext.slipstream.windowResized` telemetry event. VM service events
   are not pushed into agent context, so agents would need to poll for them —
   making the event low value in practice.

--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,13 +1,13 @@
-## 1.2.0-wip
+## 1.2.0
 
-- `ext.slipstream.perform_action` and `ext.slipstream.navigate` now wait for
-  the widget tree to settle before returning, giving animations and navigation
+- `ext.slipstream.perform_action` and `ext.slipstream.navigate` now wait for the
+  widget tree to settle before returning, giving animations and navigation
   transitions time to complete before the next tool call.
 - Add a persistent error banner: `FlutterError.onError` is intercepted and
   surfaces errors as a red chip near the top of the screen showing a running
-  count and a brief summary, e.g. `(3) flutter.error: Null check operator…`.
-  The banner is visible in agent screenshots and clears automatically on hot
-  reload or via the new `ext.slipstream.clear_errors` extension.
+  count and a brief summary, e.g. `(3) flutter.error: Null check operator…`. The
+  banner is visible in agent screenshots and clears automatically on hot reload
+  or via the new `ext.slipstream.clear_errors` extension.
 - Add `ext.slipstream.clear_errors` extension: dismisses the error banner (call
   after `get_output` or whenever the agent has acknowledged the errors).
 - Add `byTextContaining` finder: matches a `Text` widget whose content contains

--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.2.0-wip
+
+- `ext.slipstream.perform_action` and `ext.slipstream.navigate` now wait for
+  the widget tree to settle before returning, giving animations and navigation
+  transitions time to complete before the next tool call.
+- Remove the `ext.slipstream.windowResized` telemetry event. VM service events
+  are not pushed into agent context, so agents would need to poll for them —
+  making the event low value in practice.
+
 ## 1.1.1
 
 - Fix ghost overlay not appearing in apps that use `MaterialApp.router` (e.g.

--- a/slipstream_agent/docs/notes.md
+++ b/slipstream_agent/docs/notes.md
@@ -20,6 +20,3 @@ Visualizations:
 | `close_app`                    | -                                                      |
 
 ## Other
-
-- [ ] we have a use case for a general x,y tap - dismissing a dialog, ...; or
-      perhaps a 'dismiss dialog' semantic action, ...

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -328,33 +328,6 @@ Events are posted to the VM service `Extension` stream via
 `dart:developer.postEvent`. Clients subscribe with `streamListen('Extension')`
 and filter by `event.extensionKind`.
 
-### `ext.slipstream.windowResized`
-
-Fired whenever the window metrics change (resize, rotation, device pixel ratio
-change). Backed by `WidgetsBindingObserver.didChangeMetrics`.
-
-**Payload:**
-
-```json
-{
-  "viewId": 0,
-  "physicalWidth": 1170.0,
-  "physicalHeight": 2532.0,
-  "devicePixelRatio": 3.0,
-  "logicalWidth": 390.0,
-  "logicalHeight": 844.0
-}
-```
-
-<!-- prettier-ignore-start -->
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `viewId` | int | Identifies the view that changed (relevant for multi-window apps) |
-| `physicalWidth` / `physicalHeight` | double | Dimensions in physical pixels |
-| `devicePixelRatio` | double | Physical pixels per logical pixel |
-| `logicalWidth` / `logicalHeight` | double | Dimensions in logical pixels (`physical / devicePixelRatio`) |
-<!-- prettier-ignore-end -->
-
 ### `ext.slipstream.routeChanged`
 
 Fired whenever the registered router adapter's route changes. Requires

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -43,7 +43,7 @@ installed.
 | Name          | Type   | Required     | Description                                                |
 | ------------- | ------ | ------------ | ---------------------------------------------------------- |
 | `action`      | String | yes          | `"tap"` or `"set_text"`                                    |
-| `finder`      | String | yes          | `"byKey"`, `"byType"`, `"byText"`, or `"bySemanticsLabel"` |
+| `finder`      | String | yes          | `"byKey"`, `"byType"`, `"byText"`, `"byTextContaining"`, or `"bySemanticsLabel"` |
 | `finderValue` | String | yes          | Value to match against the chosen finder                   |
 | `text`        | String | for set_text | Text to set; replaces the field's current content          |
 
@@ -54,6 +54,7 @@ installed.
 | `byKey`            | Widget has a `ValueKey<String>` equal to `finderValue`, or a `ValueKey<int>` whose `.toString()` equals `finderValue` |
 | `byType`           | `widget.runtimeType.toString() == finderValue` (e.g. `"ElevatedButton"`)                                              |
 | `byText`           | Widget is a `Text` and `Text.data == finderValue`                                                                     |
+| `byTextContaining` | Widget is a `Text` and `Text.data` contains `finderValue` as a substring (useful when displayed text is truncated)    |
 | `bySemanticsLabel` | Widget is a `Semantics` and `properties.label == finderValue`                                                         |
 
 The tree is walked depth-first from the root; the first match is used.

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -323,6 +323,24 @@ ignored if omitted.
 
 ---
 
+## `ext.slipstream.clear_errors`
+
+Clears the persistent `flutter.error` banner from the ghost overlay. Call after
+reading error output (e.g. after `get_output`) or after a hot reload to
+acknowledge accumulated errors.
+
+The banner is also cleared automatically on hot reload (via `State.reassemble`).
+
+**Parameters:** none
+
+**Returns:**
+
+```json
+{ "ok": true }
+```
+
+---
+
 ## Events
 
 Events are posted to the VM service `Extension` stream via

--- a/slipstream_agent/docs/service_extensions.md
+++ b/slipstream_agent/docs/service_extensions.md
@@ -40,22 +40,22 @@ installed.
 
 **Parameters:**
 
-| Name          | Type   | Required     | Description                                                |
-| ------------- | ------ | ------------ | ---------------------------------------------------------- |
-| `action`      | String | yes          | `"tap"` or `"set_text"`                                    |
+| Name          | Type   | Required     | Description                                                                      |
+| ------------- | ------ | ------------ | -------------------------------------------------------------------------------- |
+| `action`      | String | yes          | `"tap"` or `"set_text"`                                                          |
 | `finder`      | String | yes          | `"byKey"`, `"byType"`, `"byText"`, `"byTextContaining"`, or `"bySemanticsLabel"` |
-| `finderValue` | String | yes          | Value to match against the chosen finder                   |
-| `text`        | String | for set_text | Text to set; replaces the field's current content          |
+| `finderValue` | String | yes          | Value to match against the chosen finder                                         |
+| `text`        | String | for set_text | Text to set; replaces the field's current content                                |
 
 **Finder semantics:**
 
-| Finder             | Matches when                                                                                                          |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------- |
-| `byKey`            | Widget has a `ValueKey<String>` equal to `finderValue`, or a `ValueKey<int>` whose `.toString()` equals `finderValue` |
-| `byType`           | `widget.runtimeType.toString() == finderValue` (e.g. `"ElevatedButton"`)                                              |
-| `byText`           | Widget is a `Text` and `Text.data == finderValue`                                                                     |
-| `byTextContaining` | Widget is a `Text` and `Text.data` contains `finderValue` as a substring (useful when displayed text is truncated)    |
-| `bySemanticsLabel` | Widget is a `Semantics` and `properties.label == finderValue`                                                         |
+| Finder             | Matches when                                                                                                                      |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `byKey`            | Widget has a `ValueKey<String>` equal to `finderValue`, or a `ValueKey<int>` whose `.toString()` equals `finderValue`             |
+| `byType`           | `widget.runtimeType.toString() == finderValue` (e.g. `"ElevatedButton"`)                                                          |
+| `byText`           | Widget is a `Text` and `Text.data == finderValue`                                                                                 |
+| `byTextContaining` | Widget is a `Text` and `Text.data` contains `finderValue` as a substring (useful when displayed text is truncated) (since v1.2.0) |
+| `bySemanticsLabel` | Widget is a `Semantics` and `properties.label == finderValue`                                                                     |
 
 The tree is walked depth-first from the root; the first match is used.
 
@@ -323,7 +323,7 @@ ignored if omitted.
 
 ---
 
-## `ext.slipstream.clear_errors`
+## `ext.slipstream.clear_errors` (since v1.2.0)
 
 Clears the persistent `flutter.error` banner from the ghost overlay. Call after
 reading error output (e.g. after `get_output`) or after a hot reload to

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -93,8 +93,8 @@ class Agent {
       ParameterDescription(
         name: 'finder',
         type: 'String',
-        description: 'How to find the widget: "byKey", "byType", "byText", or '
-            '"bySemanticsLabel".',
+        description: 'How to find the widget: "byKey", "byType", "byText", '
+            '"byTextContaining", or "bySemanticsLabel".',
         required: true,
       ),
       ParameterDescription(

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -5,6 +5,7 @@ import 'package:flutter/widgets.dart';
 import 'package:service_extensions/service_extensions.dart';
 
 import 'actions.dart';
+import 'common.dart';
 import 'finder.dart';
 import 'ghost_overlay.dart';
 import 'overlays.dart';
@@ -232,7 +233,12 @@ class Agent {
         error = 'interact: unknown action "$action"';
     }
 
-    if (error != null) return {'ok': false, 'error': error};
+    if (error != null) {
+      return {'ok': false, 'error': error};
+    }
+
+    await pumpAndMostlySettle();
+
     return {'ok': true};
   }
 
@@ -309,6 +315,7 @@ class Agent {
     try {
       GhostOverlay.log('navigate', details: path, kind: 'interact');
       _router!.go(root, path);
+      await pumpAndMostlySettle();
       return {'ok': true};
     } catch (e) {
       return {'ok': false, 'error': 'navigate: $e'};

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -75,6 +75,11 @@ class Agent {
       _logExtension,
     );
 
+    registerServiceExtension(
+      _clearErrorsDescription,
+      _clearErrorsExtension,
+    );
+
     initTelemetry();
   }
 
@@ -336,6 +341,7 @@ class Agent {
   Future<Map<String, Object?>> _pingExtension(
       ExtensionParameters parameters) async {
     GhostOverlay.install();
+    GhostOverlay.showError('test error'); // TODO: remove
     return {
       'version': packageVersion,
     };
@@ -480,6 +486,23 @@ class Agent {
       ReturnDescription(name: 'ok', type: 'bool', description: 'Always true.'),
     ],
   );
+
+  final ServiceDescription _clearErrorsDescription = ServiceDescription(
+    name: 'ext.slipstream.clear_errors',
+    description:
+        'Clears the persistent flutter.error banner from the ghost overlay. '
+        'Call after reading error output (e.g. after get_output) or after a '
+        'hot reload to acknowledge the errors.',
+    returns: [
+      ReturnDescription(name: 'ok', type: 'bool', description: 'Always true.'),
+    ],
+  );
+
+  Future<Map<String, Object?>> _clearErrorsExtension(
+      ExtensionParameters _) async {
+    GhostOverlay.clearErrors();
+    return {'ok': true};
+  }
 
   Future<Map<String, Object?>> _logExtension(
       ExtensionParameters parameters) async {

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -22,7 +22,6 @@ class Agent {
   static Agent get instance => _instance;
 
   bool _initialized = false;
-  RouterAdapter? _router;
 
   Agent._();
 
@@ -33,57 +32,159 @@ class Agent {
     if (_initialized) return;
     _initialized = true;
 
-    _router = router;
-
-    registerServiceExtension(
-      _pingDescription,
-      _pingExtension,
-    );
-
-    registerServiceExtension(
-      _getRouteDescription,
-      _getRouteExtension,
-    );
-
-    registerServiceExtension(
-      _navigateDescription,
-      _navigateExtension,
-    );
-
-    registerServiceExtension(
-      _performActionDescription,
-      _performActionExtension,
-    );
-
-    registerServiceExtension(
-      _enableSemanticsDescription,
-      _enableSemanticsExtension,
-    );
-
-    registerServiceExtension(
-      _getSemanticsDescription,
-      _getSemanticsExtension,
-    );
-
-    registerServiceExtension(
-      _overlaysDescription,
-      _overlaysExtension,
-    );
-
-    registerServiceExtension(
-      _logDescription,
-      _logExtension,
-    );
-
-    registerServiceExtension(
-      _clearErrorsDescription,
-      _clearErrorsExtension,
-    );
+    for (final ext in [
+      _PingExtension(),
+      _GetRouteExtension(router),
+      _NavigateExtension(router),
+      _PerformActionExtension(),
+      _EnableSemanticsExtension(),
+      _GetSemanticsExtension(),
+      _OverlaysExtension(),
+      _LogExtension(),
+      _ClearErrorsExtension(),
+    ]) {
+      registerServiceExtension(ext.description, ext.handleCall);
+    }
 
     initTelemetry();
   }
+}
 
-  final ServiceDescription _performActionDescription = ServiceDescription(
+Future<void> _waitForNextFrame() async {
+  final completer = Completer<void>();
+  WidgetsBinding.instance.scheduleFrameCallback(
+    (timeStamp) => completer.complete(),
+    scheduleNewFrame: true,
+  );
+  await completer.future;
+}
+
+abstract class AgentExtension {
+  ServiceDescription get description;
+
+  Future<Map<String, Object?>> handleCall(ExtensionParameters parameters);
+}
+
+// ---------------------------------------------------------------------------
+// Extensions
+
+class _PingExtension extends AgentExtension {
+  @override
+  final ServiceDescription description = ServiceDescription(
+    name: 'ext.slipstream.ping',
+    description: 'Checks the status of the Slipstream agent.',
+    returns: [
+      ReturnDescription(
+        name: 'version',
+        type: 'String',
+        description: 'The slipstream_agent version.',
+      ),
+    ],
+  );
+
+  @override
+  Future<Map<String, Object?>> handleCall(ExtensionParameters _) async {
+    GhostOverlay.install();
+    GhostOverlay.showError('test error'); // TODO: remove
+    return {'version': packageVersion};
+  }
+}
+
+class _GetRouteExtension extends AgentExtension {
+  _GetRouteExtension(this._router);
+
+  final RouterAdapter? _router;
+
+  @override
+  final ServiceDescription description = ServiceDescription(
+    name: 'ext.slipstream.get_route',
+    description:
+        'Returns the current route path from the registered router adapter. '
+        'Requires SlipstreamAgent.init(router: ...) to have been called.',
+    returns: [
+      ReturnDescription(
+        name: 'path',
+        type: 'String',
+        description: 'The current route path, e.g. "/podcast/123".',
+      ),
+    ],
+  );
+
+  @override
+  Future<Map<String, Object?>> handleCall(ExtensionParameters _) async {
+    GhostOverlay.log('get route', kind: 'read');
+    final path = _router?.currentPath();
+    if (path == null) {
+      return {
+        'ok': false,
+        'error': 'get_route: no router adapter registered or path unavailable',
+      };
+    }
+    return {'ok': true, 'path': path};
+  }
+}
+
+class _NavigateExtension extends AgentExtension {
+  _NavigateExtension(this._router);
+
+  final RouterAdapter? _router;
+
+  @override
+  final ServiceDescription description = ServiceDescription(
+    name: 'ext.slipstream.navigate',
+    description: 'Navigates the app to a route path via the registered router '
+        'adapter. Requires SlipstreamAgent.init(router: ...) to have been '
+        'called.',
+    parameters: [
+      ParameterDescription(
+        name: 'path',
+        type: 'String',
+        description: 'Route path to navigate to, e.g. "/podcast/123".',
+        required: true,
+      ),
+    ],
+    returns: [
+      ReturnDescription(
+          name: 'ok', type: 'bool', description: 'The status of the call.'),
+      ReturnDescription(
+          name: 'error',
+          type: 'String',
+          description: 'A message describing any error.'),
+    ],
+  );
+
+  @override
+  Future<Map<String, Object?>> handleCall(ExtensionParameters parameters) async {
+    final String path = parameters.asStringRequired('path');
+
+    if (_router == null) {
+      return {
+        'ok': false,
+        'error': 'navigate: no router adapter registered. Call '
+            'SlipstreamAgent.init(router: GoRouterAdapter(appRouter)) in '
+            'main().',
+      };
+    }
+
+    final Element? root = WidgetsBinding.instance.rootElement;
+    if (root == null) {
+      return {'ok': false, 'error': 'navigate: widget tree not yet built'};
+    }
+
+    try {
+      GhostOverlay.log('navigate', details: path, kind: 'interact');
+      _router.go(root, path);
+      await pumpAndMostlySettle();
+      return {'ok': true};
+    } catch (e) {
+      return {'ok': false, 'error': 'navigate: $e'};
+    }
+  }
+}
+
+class _PerformActionExtension extends AgentExtension {
+  @override
+  final ServiceDescription description = ServiceDescription(
     name: 'ext.slipstream.perform_action',
     description:
         'Performs a UI action (tap, set_text) on a widget located by a '
@@ -142,13 +243,12 @@ class Agent {
       ReturnDescription(
           name: 'error',
           type: 'String',
-          description: 'A message describing any error.')
+          description: 'A message describing any error.'),
     ],
   );
 
-  Future<Map<String, Object?>> _performActionExtension(
-    ExtensionParameters parameters,
-  ) async {
+  @override
+  Future<Map<String, Object?>> handleCall(ExtensionParameters parameters) async {
     final String action = parameters.asStringRequired('action');
     final String finder = parameters.asStringRequired('finder');
     final String finderValue = parameters.asStringRequired('finderValue');
@@ -246,122 +346,28 @@ class Agent {
 
     return {'ok': true};
   }
+}
 
-  final ServiceDescription _getRouteDescription = ServiceDescription(
-    name: 'ext.slipstream.get_route',
-    description:
-        'Returns the current route path from the registered router adapter. '
-        'Requires SlipstreamAgent.init(router: ...) to have been called.',
-    returns: [
-      ReturnDescription(
-        name: 'path',
-        type: 'String',
-        description: 'The current route path, e.g. "/podcast/123".',
-      ),
-    ],
-  );
-
-  Future<Map<String, Object?>> _getRouteExtension(
-      ExtensionParameters parameters) async {
-    GhostOverlay.log('get route', kind: 'read');
-    final path = _router?.currentPath();
-    if (path == null) {
-      return {
-        'ok': false,
-        'error': 'get_route: no router adapter registered or path unavailable',
-      };
-    }
-    return {'ok': true, 'path': path};
-  }
-
-  final ServiceDescription _navigateDescription = ServiceDescription(
-    name: 'ext.slipstream.navigate',
-    description: 'Navigates the app to a route path via the registered router '
-        'adapter. Requires SlipstreamAgent.init(router: ...) to have been '
-        'called.',
-    parameters: [
-      ParameterDescription(
-        name: 'path',
-        type: 'String',
-        description: 'Route path to navigate to, e.g. "/podcast/123".',
-        required: true,
-      ),
-    ],
-    returns: [
-      ReturnDescription(
-          name: 'ok', type: 'bool', description: 'The status of the call.'),
-      ReturnDescription(
-          name: 'error',
-          type: 'String',
-          description: 'A message describing any error.')
-    ],
-  );
-
-  Future<Map<String, Object?>> _navigateExtension(
-    ExtensionParameters parameters,
-  ) async {
-    final String path = parameters.asStringRequired('path');
-
-    if (_router == null) {
-      return {
-        'ok': false,
-        'error': 'navigate: no router adapter registered. Call '
-            'SlipstreamAgent.init(router: GoRouterAdapter(appRouter)) in '
-            'main().',
-      };
-    }
-
-    // Obtain a BuildContext from the root element.
-    final Element? root = WidgetsBinding.instance.rootElement;
-    if (root == null) {
-      return {'ok': false, 'error': 'navigate: widget tree not yet built'};
-    }
-
-    try {
-      GhostOverlay.log('navigate', details: path, kind: 'interact');
-      _router!.go(root, path);
-      await pumpAndMostlySettle();
-      return {'ok': true};
-    } catch (e) {
-      return {'ok': false, 'error': 'navigate: $e'};
-    }
-  }
-
-  final ServiceDescription _pingDescription = ServiceDescription(
-    name: 'ext.slipstream.ping',
-    description: 'Checks the status of the Slipstream agent.',
-    returns: [
-      ReturnDescription(
-          name: 'version',
-          type: 'String',
-          description: 'The slipstream_agent version.')
-    ],
-  );
-
-  Future<Map<String, Object?>> _pingExtension(
-      ExtensionParameters parameters) async {
-    GhostOverlay.install();
-    GhostOverlay.showError('test error'); // TODO: remove
-    return {
-      'version': packageVersion,
-    };
-  }
-
-  final ServiceDescription _enableSemanticsDescription = ServiceDescription(
+class _EnableSemanticsExtension extends AgentExtension {
+  @override
+  final ServiceDescription description = ServiceDescription(
     name: 'ext.slipstream.enable_semantics',
     description: 'Enables the Flutter semantics tree and schedules a frame to '
         'ensure it is populated.',
   );
 
-  Future<Map<String, Object?>> _enableSemanticsExtension(
-      ExtensionParameters parameters) async {
+  @override
+  Future<Map<String, Object?>> handleCall(ExtensionParameters _) async {
     GhostOverlay.log('enable semantics', kind: 'read');
     RendererBinding.instance.ensureSemantics();
     await _waitForNextFrame();
     return {};
   }
+}
 
-  final ServiceDescription _getSemanticsDescription = ServiceDescription(
+class _GetSemanticsExtension extends AgentExtension {
+  @override
+  final ServiceDescription description = ServiceDescription(
     name: 'ext.slipstream.get_semantics',
     description:
         'Returns a flat list of visible semantics nodes from the running app. '
@@ -387,15 +393,18 @@ class Agent {
     ],
   );
 
-  Future<Map<String, Object?>> _getSemanticsExtension(
-      ExtensionParameters parameters) async {
+  @override
+  Future<Map<String, Object?>> handleCall(ExtensionParameters _) async {
     GhostOverlay.log('get semantics', kind: 'read', viz: 'semantics');
     final (nodes, error) = getSemanticsNodes();
     if (error != null) return {'ok': false, 'error': error};
     return {'ok': true, 'nodes': nodes!.map((n) => n.toMap()).toList()};
   }
+}
 
-  final ServiceDescription _overlaysDescription = ServiceDescription(
+class _OverlaysExtension extends AgentExtension {
+  @override
+  final ServiceDescription description = ServiceDescription(
     name: 'ext.slipstream.overlays',
     description:
         'Shows or hides all Slipstream-managed overlays (debug banner, and '
@@ -421,20 +430,18 @@ class Agent {
     ],
   );
 
-  Future<Map<String, Object?>> _overlaysExtension(
-      ExtensionParameters parameters) async {
+  @override
+  Future<Map<String, Object?>> handleCall(ExtensionParameters parameters) async {
     final enabled = parameters.asBoolRequired('enabled');
-
-    // This command shouldn't have an overlay message.
-    // GhostOverlay.log('overlays', details: enabled ? 'show' : 'hide');
     setOverlaysEnabled(enabled);
-
     await _waitForNextFrame();
-
     return {'ok': true};
   }
+}
 
-  final ServiceDescription _logDescription = ServiceDescription(
+class _LogExtension extends AgentExtension {
+  @override
+  final ServiceDescription description = ServiceDescription(
     name: 'ext.slipstream.log',
     description:
         'Logs an agent command to the ghost overlay command log. Called by the '
@@ -487,7 +494,23 @@ class Agent {
     ],
   );
 
-  final ServiceDescription _clearErrorsDescription = ServiceDescription(
+  @override
+  Future<Map<String, Object?>> handleCall(ExtensionParameters parameters) async {
+    GhostOverlay.log(
+      parameters.asStringRequired('command'),
+      details: parameters.asString('details'),
+      kind: parameters.asString('kind'),
+      finder: parameters.asString('finder'),
+      finderValue: parameters.asString('finderValue'),
+      viz: parameters.asString('viz'),
+    );
+    return {'ok': true};
+  }
+}
+
+class _ClearErrorsExtension extends AgentExtension {
+  @override
+  final ServiceDescription description = ServiceDescription(
     name: 'ext.slipstream.clear_errors',
     description:
         'Clears the persistent flutter.error banner from the ghost overlay. '
@@ -498,35 +521,9 @@ class Agent {
     ],
   );
 
-  Future<Map<String, Object?>> _clearErrorsExtension(
-      ExtensionParameters _) async {
+  @override
+  Future<Map<String, Object?>> handleCall(ExtensionParameters _) async {
     GhostOverlay.clearErrors();
     return {'ok': true};
-  }
-
-  Future<Map<String, Object?>> _logExtension(
-      ExtensionParameters parameters) async {
-    final String command = parameters.asStringRequired('command');
-    final String? details = parameters.asString('details');
-    final String? kind = parameters.asString('kind');
-    final String? finder = parameters.asString('finder');
-    final String? finderValue = parameters.asString('finderValue');
-    final String? viz = parameters.asString('viz');
-    GhostOverlay.log(command,
-        details: details,
-        kind: kind,
-        finder: finder,
-        finderValue: finderValue,
-        viz: viz);
-    return {'ok': true};
-  }
-
-  // A addPostFrameCallback() callback may be more correct here.
-  Future<void> _waitForNextFrame() async {
-    final completer = Completer();
-    WidgetsBinding.instance.scheduleFrameCallback(
-        (timeStamp) => completer.complete(),
-        scheduleNewFrame: true);
-    await completer.future;
   }
 }

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -85,7 +85,6 @@ class _PingExtension extends AgentExtension {
   @override
   Future<Map<String, Object?>> handleCall(ExtensionParameters _) async {
     GhostOverlay.install();
-    GhostOverlay.showError('test error'); // TODO: remove
     return {'version': packageVersion};
   }
 }
@@ -154,7 +153,8 @@ class _NavigateExtension extends AgentExtension {
   );
 
   @override
-  Future<Map<String, Object?>> handleCall(ExtensionParameters parameters) async {
+  Future<Map<String, Object?>> handleCall(
+      ExtensionParameters parameters) async {
     final String path = parameters.asStringRequired('path');
 
     if (_router == null) {
@@ -248,7 +248,8 @@ class _PerformActionExtension extends AgentExtension {
   );
 
   @override
-  Future<Map<String, Object?>> handleCall(ExtensionParameters parameters) async {
+  Future<Map<String, Object?>> handleCall(
+      ExtensionParameters parameters) async {
     final String action = parameters.asStringRequired('action');
     final String finder = parameters.asStringRequired('finder');
     final String finderValue = parameters.asStringRequired('finderValue');
@@ -431,7 +432,8 @@ class _OverlaysExtension extends AgentExtension {
   );
 
   @override
-  Future<Map<String, Object?>> handleCall(ExtensionParameters parameters) async {
+  Future<Map<String, Object?>> handleCall(
+      ExtensionParameters parameters) async {
     final enabled = parameters.asBoolRequired('enabled');
     setOverlaysEnabled(enabled);
     await _waitForNextFrame();
@@ -495,7 +497,8 @@ class _LogExtension extends AgentExtension {
   );
 
   @override
-  Future<Map<String, Object?>> handleCall(ExtensionParameters parameters) async {
+  Future<Map<String, Object?>> handleCall(
+      ExtensionParameters parameters) async {
     GhostOverlay.log(
       parameters.asStringRequired('command'),
       details: parameters.asString('details'),

--- a/slipstream_agent/lib/src/common.dart
+++ b/slipstream_agent/lib/src/common.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// Waits for the widget tree to settle, similar to Flutter's test
+/// [pumpAndSettle], but adapted for a live app where infinite animations may
+/// be running.
+///
+/// Rather than waiting for *all* frames to stop (which never happens with
+/// looping animations), this function waits until [idleThreshold] consecutive
+/// ~16 ms intervals pass with no new frame scheduled. That is enough quiet
+/// time for navigation transitions, Hero animations, and most one-shot UI work
+/// to complete.
+///
+/// If [timeout] elapses first the function returns silently — it never throws.
+Future<void> pumpAndMostlySettle({
+  Duration step = const Duration(milliseconds: 16),
+  Duration timeout = const Duration(seconds: 5),
+  int idleThreshold = 5,
+}) async {
+  final binding = WidgetsBinding.instance;
+  final endTime = DateTime.now().add(timeout);
+  var idleCount = 0;
+
+  while (idleCount < idleThreshold) {
+    if (DateTime.now().isAfter(endTime)) return;
+
+    if (binding.hasScheduledFrame) {
+      idleCount = 0;
+      final completer = Completer<void>();
+      binding.addPostFrameCallback((_) => completer.complete());
+      await completer.future;
+    } else {
+      idleCount++;
+      await Future.delayed(step);
+    }
+  }
+}

--- a/slipstream_agent/lib/src/finder.dart
+++ b/slipstream_agent/lib/src/finder.dart
@@ -8,6 +8,8 @@ import 'package:flutter/widgets.dart';
 ///   representation)
 /// - `byType` — matches the widget's `runtimeType.toString()` exactly
 /// - `byText` — matches a [Text] widget whose `data` equals [value]
+/// - `byTextContaining` — matches a [Text] widget whose `data` contains [value]
+///   as a substring
 /// - `bySemanticsLabel` — matches a [Semantics] widget whose label equals
 ///   [value]
 ///
@@ -43,6 +45,10 @@ bool _matches(Element element, String finder, String value) {
 
     case 'byText':
       if (widget is Text) return widget.data == value;
+      return false;
+
+    case 'byTextContaining':
+      if (widget is Text) return widget.data?.contains(value) ?? false;
       return false;
 
     case 'bySemanticsLabel':

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -30,6 +30,7 @@ class GhostOverlay {
   static const Duration _chipDuration = Duration(seconds: 3);
   static const Duration _semanticsDuration = Duration(seconds: 3);
   static const Duration _outlineDuration = Duration(milliseconds: 750);
+  static const Duration _toastDuration = Duration(milliseconds: 280);
 
   static final GlobalKey<_GhostOverlayState> _key = GlobalKey();
   static OverlayEntry? _entry;
@@ -44,6 +45,29 @@ class GhostOverlay {
   static final List<_LogMessage> _pending = [];
 
   static bool _visible = true;
+
+  // Persistent error state — source of truth; the widget state mirrors this.
+  static int _errorCount = 0;
+  static String _errorSummary = '';
+
+  /// Records a new `flutter.error` event and shows the persistent error banner.
+  ///
+  /// The banner displays a running count and the most recent [summary]. Call
+  /// [clearErrors] to dismiss it (e.g. after the agent has read the logs or
+  /// after a hot reload).
+  static void showError(String summary) {
+    _errorCount++;
+    _errorSummary = summary;
+    _key.currentState?.setError(_errorCount, _errorSummary);
+    _ensureInstalled();
+  }
+
+  /// Clears the persistent error banner.
+  static void clearErrors() {
+    _errorCount = 0;
+    _errorSummary = '';
+    _key.currentState?.setError(0, '');
+  }
 
   /// Installs the ghost overlay and permanently disables the Flutter debug
   /// banner for the life of the Slipstream session.
@@ -140,11 +164,16 @@ class GhostOverlay {
 
   static void _flushPending() {
     final state = _key.currentState;
-    if (state == null || _pending.isEmpty) return;
-    for (final entry in _pending) {
-      state.addLogMessage(entry);
+    if (state == null) return;
+    if (_pending.isNotEmpty) {
+      for (final entry in _pending) {
+        state.addLogMessage(entry);
+      }
+      _pending.clear();
     }
-    _pending.clear();
+    if (_errorCount > 0) {
+      state.setError(_errorCount, _errorSummary);
+    }
   }
 
   static OverlayState? _findOverlay() {
@@ -240,6 +269,18 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
 
   bool _visible = true;
 
+  // Persistent error display — mirrors GhostOverlay._errorCount/Summary.
+  int _errorCount = 0;
+  String _errorSummary = '';
+
+  void setError(int count, String summary) {
+    if (!mounted) return;
+    setState(() {
+      _errorCount = count;
+      _errorSummary = summary;
+    });
+  }
+
   // Trigger counters and data for the three visualization sub-widgets.
   // Incrementing a counter causes the corresponding widget to start its
   // animation via didUpdateWidget; no GlobalKeys needed.
@@ -265,6 +306,11 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
         _chipKeys.clear();
         _outlineRect = null;
         _semanticsRects = const [];
+        _errorCount = 0;
+        _errorSummary = '';
+      } else {
+        _errorCount = GhostOverlay._errorCount;
+        _errorSummary = GhostOverlay._errorSummary;
       }
     });
   }
@@ -364,6 +410,13 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
   }
 
   @override
+  void reassemble() {
+    super.reassemble();
+    // Hot reload — clear accumulated errors so the banner resets cleanly.
+    GhostOverlay.clearErrors();
+  }
+
+  @override
   void dispose() {
     for (final t in _timers) {
       t.cancel();
@@ -406,6 +459,19 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
               ),
             ),
           ),
+          // Persistent error banner near the top of the screen.
+          if (_errorCount > 0)
+            Positioned(
+              top: (MediaQuery.maybePaddingOf(context)?.top ?? 0.0) + 18,
+              left: 12,
+              right: 12,
+              child: Stack(
+                alignment: Alignment.topCenter,
+                children: [
+                  _ErrorBanner(count: _errorCount, summary: _errorSummary),
+                ],
+              ),
+            ),
           // Command-log chips — share the same space; newer chips are
           // painted in front of older ones.
           if (_entries.isNotEmpty)
@@ -699,6 +765,82 @@ class _SemanticsNodeWidget extends StatelessWidget {
 }
 
 // ---------------------------------------------------------------------------
+// Persistent error banner
+
+const Color _errorColor = Color(0xFFB71C1C);
+
+const TextStyle _errorTextStyle = TextStyle(
+  color: Color(0xFFFFFFFF),
+  fontSize: 12 * 0.85,
+  fontWeight: FontWeight.w900,
+  decoration: TextDecoration.none,
+);
+
+final BoxDecoration _errorDecoration = BoxDecoration(
+  color: _errorColor,
+  borderRadius: BorderRadius.circular(6),
+  boxShadow: const [
+    BoxShadow(
+      color: Color(0x55000000),
+      blurRadius: 6,
+      offset: Offset(0, 2),
+    ),
+  ],
+);
+
+class _ErrorBanner extends StatelessWidget {
+  const _ErrorBanner({required this.count, required this.summary});
+
+  final int count;
+  final String? summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final errorDesc =
+        summary == null ? 'flutter.error' : 'flutter.error: $summary';
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        // error count
+        DecoratedBox(
+          decoration: _errorDecoration,
+          child: Padding(
+            padding:
+                const EdgeInsets.only(left: 8, right: 8, top: 1, bottom: 3),
+            child: Text('$count', style: _errorTextStyle),
+          ),
+        ),
+
+        SizedBox(width: 4),
+
+        // error icon and message
+        DecoratedBox(
+          decoration: _errorDecoration,
+          child: Padding(
+            padding:
+                const EdgeInsets.only(left: 8, right: 8, top: 1, bottom: 3),
+            child: Row(
+              children: [
+                Icon(Icons.error_outline,
+                    size: 11, color: const Color(0xFFFFFFFF)),
+                const SizedBox(width: 4),
+                Text(
+                  errorDesc,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: _errorTextStyle,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Command-log chip
 
 class _EntryChip extends StatefulWidget {
@@ -712,8 +854,6 @@ class _EntryChip extends StatefulWidget {
 }
 
 class _EntryChipState extends State<_EntryChip> with TickerProviderStateMixin {
-  static const Duration _animDuration = Duration(milliseconds: 280);
-
   late final AnimationController _enterController;
   late final AnimationController _exitController;
   late final Animation<Offset> _enterSlide;
@@ -723,9 +863,11 @@ class _EntryChipState extends State<_EntryChip> with TickerProviderStateMixin {
   void initState() {
     super.initState();
 
-    _enterController = AnimationController(vsync: this, duration: _animDuration)
-      ..forward();
-    _exitController = AnimationController(vsync: this, duration: _animDuration);
+    _enterController =
+        AnimationController(vsync: this, duration: GhostOverlay._toastDuration)
+          ..forward();
+    _exitController =
+        AnimationController(vsync: this, duration: GhostOverlay._toastDuration);
 
     // Values are fractions of the screen height (0.1 = 10% of screen height).
     _enterSlide = Tween<Offset>(

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -270,14 +270,30 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
   bool _visible = true;
 
   // Persistent error display — mirrors GhostOverlay._errorCount/Summary.
+  final GlobalKey<_ErrorBannerState> _errorBannerKey = GlobalKey();
+  bool _showErrorBanner = false;
   int _errorCount = 0;
   String _errorSummary = '';
 
   void setError(int count, String summary) {
     if (!mounted) return;
+    if (count > 0) {
+      setState(() {
+        _errorCount = count;
+        _errorSummary = summary;
+        _showErrorBanner = true;
+      });
+    } else {
+      _errorBannerKey.currentState?.triggerExit();
+    }
+  }
+
+  void _onErrorBannerExited() {
+    if (!mounted) return;
     setState(() {
-      _errorCount = count;
-      _errorSummary = summary;
+      _showErrorBanner = false;
+      _errorCount = 0;
+      _errorSummary = '';
     });
   }
 
@@ -306,11 +322,13 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
         _chipKeys.clear();
         _outlineRect = null;
         _semanticsRects = const [];
+        _showErrorBanner = false;
         _errorCount = 0;
         _errorSummary = '';
       } else {
         _errorCount = GhostOverlay._errorCount;
         _errorSummary = GhostOverlay._errorSummary;
+        _showErrorBanner = _errorCount > 0;
       }
     });
   }
@@ -460,16 +478,16 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
             ),
           ),
           // Persistent error banner near the top of the screen.
-          if (_errorCount > 0)
+          if (_showErrorBanner)
             Positioned(
-              top: (MediaQuery.maybePaddingOf(context)?.top ?? 0.0) + 18,
+              top: (MediaQuery.maybePaddingOf(context)?.top ?? 0.0) + 16,
               left: 12,
               right: 12,
-              child: Stack(
-                alignment: Alignment.topCenter,
-                children: [
-                  _ErrorBanner(count: _errorCount, summary: _errorSummary),
-                ],
+              child: _ErrorBanner(
+                key: _errorBannerKey,
+                count: _errorCount,
+                summary: _errorSummary,
+                onExited: _onErrorBannerExited,
               ),
             ),
           // Command-log chips — share the same space; newer chips are
@@ -788,54 +806,117 @@ final BoxDecoration _errorDecoration = BoxDecoration(
   ],
 );
 
-class _ErrorBanner extends StatelessWidget {
-  const _ErrorBanner({required this.count, required this.summary});
+class _ErrorBanner extends StatefulWidget {
+  const _ErrorBanner({
+    super.key,
+    required this.count,
+    required this.summary,
+    required this.onExited,
+  });
 
   final int count;
   final String? summary;
+  final VoidCallback onExited;
+
+  @override
+  State<_ErrorBanner> createState() => _ErrorBannerState();
+}
+
+class _ErrorBannerState extends State<_ErrorBanner>
+    with TickerProviderStateMixin {
+  static const Duration _animDuration = Duration(milliseconds: 280);
+
+  late final AnimationController _enterController;
+  late final AnimationController _exitController;
+  late final Animation<Offset> _enterSlide;
+  late final Animation<Offset> _exitSlide;
+
+  @override
+  void initState() {
+    super.initState();
+    _enterController = AnimationController(vsync: this, duration: _animDuration)
+      ..forward();
+    _exitController = AnimationController(vsync: this, duration: _animDuration);
+
+    _enterSlide = Tween<Offset>(
+      begin: const Offset(0, -0.1),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(parent: _enterController, curve: Curves.easeOut));
+
+    _exitSlide = Tween<Offset>(
+      begin: Offset.zero,
+      end: const Offset(0, -0.1),
+    ).animate(CurvedAnimation(parent: _exitController, curve: Curves.easeIn));
+  }
+
+  void triggerExit() {
+    if (!mounted) return;
+    if (_exitController.isAnimating || _exitController.isCompleted) return;
+    _exitController.forward().then((_) {
+      if (mounted) widget.onExited();
+    });
+  }
+
+  @override
+  void dispose() {
+    _enterController.dispose();
+    _exitController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final errorDesc =
-        summary == null ? 'flutter.error' : 'flutter.error: $summary';
+    final errorDesc = widget.summary == null
+        ? 'flutter.error'
+        : 'flutter.error: ${widget.summary}';
 
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        // error count
-        DecoratedBox(
-          decoration: _errorDecoration,
-          child: Padding(
-            padding:
-                const EdgeInsets.only(left: 8, right: 8, top: 1, bottom: 3),
-            child: Text('$count', style: _errorTextStyle),
+    return AnimatedBuilder(
+      animation: Listenable.merge([_enterController, _exitController]),
+      builder: (context, child) {
+        final screenH = MediaQuery.sizeOf(context).height;
+        final dy = (_enterSlide.value.dy + _exitSlide.value.dy) * screenH;
+        return Transform.translate(offset: Offset(0, dy), child: child);
+      },
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          // error count badge — circular for single digits, pill for larger
+          Container(
+            decoration: BoxDecoration(
+              color: _errorColor,
+              borderRadius: BorderRadius.circular(50),
+              boxShadow: _errorDecoration.boxShadow,
+            ),
+            constraints: const BoxConstraints(minWidth: 22, minHeight: 22),
+            padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
+            alignment: Alignment.center,
+            child: Text('${widget.count}', style: _errorTextStyle),
           ),
-        ),
-
-        SizedBox(width: 4),
-
-        // error icon and message
-        DecoratedBox(
-          decoration: _errorDecoration,
-          child: Padding(
-            padding:
-                const EdgeInsets.only(left: 8, right: 8, top: 1, bottom: 3),
-            child: Row(
-              children: [
-                Icon(Icons.error_outline,
-                    size: 11, color: const Color(0xFFFFFFFF)),
-                const SizedBox(width: 4),
-                Text(
-                  errorDesc,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: _errorTextStyle,
-                ),
-              ],
+          const SizedBox(width: 4),
+          // error icon and message — centered in remaining space
+          DecoratedBox(
+            decoration: _errorDecoration,
+            child: Padding(
+              padding:
+                  const EdgeInsets.only(left: 8, right: 8, top: 1, bottom: 3),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.error_outline,
+                      size: 11, color: Color(0xFFFFFFFF)),
+                  const SizedBox(width: 4),
+                  Text(
+                    errorDesc,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: _errorTextStyle,
+                  ),
+                ],
+              ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -30,7 +30,6 @@ class GhostOverlay {
   static const Duration _chipDuration = Duration(seconds: 3);
   static const Duration _semanticsDuration = Duration(seconds: 3);
   static const Duration _outlineDuration = Duration(milliseconds: 750);
-  static const Duration _toastDuration = Duration(milliseconds: 280);
 
   static final GlobalKey<_GhostOverlayState> _key = GlobalKey();
   static OverlayEntry? _entry;
@@ -260,6 +259,131 @@ class _LogMessage {
 }
 
 // ---------------------------------------------------------------------------
+// Shared chip constants and decorations
+
+const Duration _chipAnimDuration = Duration(milliseconds: 280);
+
+const TextStyle _chipTextStyle = TextStyle(
+  color: Color(0xFFFFFFFF),
+  fontSize: 12 * 0.85,
+  fontWeight: FontWeight.w900,
+  decoration: TextDecoration.none,
+);
+
+const List<BoxShadow> _chipBoxShadow = [
+  BoxShadow(
+    color: Color(0x55000000),
+    blurRadius: 6,
+    offset: Offset(0, 2),
+  ),
+];
+
+const Color _errorColor = Color(0xFFB71C1C);
+
+final BoxDecoration _errorChipDecoration = BoxDecoration(
+  color: _errorColor,
+  borderRadius: BorderRadius.circular(6),
+  boxShadow: _chipBoxShadow,
+);
+
+final BoxDecoration _logChipDecoration = BoxDecoration(
+  gradient: LinearGradient(
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+    colors: [
+      Color.alphaBlend(const Color(0x28FFFFFF), ghostOverlayColor),
+      ghostOverlayColor,
+    ],
+  ),
+  borderRadius: BorderRadius.circular(6),
+  boxShadow: _chipBoxShadow,
+);
+
+// ---------------------------------------------------------------------------
+// Shared slide animation mixin
+
+/// Slide-in/slide-out animation shared by [_EntryChipState] and
+/// [_ErrorBannerState].
+///
+/// Call [initSlideAnimations] in [State.initState] and
+/// [disposeSlideAnimations] in [State.dispose]. [triggerExit] plays the exit
+/// animation and then calls [_onExitComplete]. [buildSliding] wraps a child in
+/// the combined translation.
+mixin _SlidingChipMixin<T extends StatefulWidget>
+    on State<T>, TickerProviderStateMixin<T> {
+  late final AnimationController _enterController;
+  late final AnimationController _exitController;
+  late final Animation<Offset> _enterSlide;
+  late final Animation<Offset> _exitSlide;
+
+  void initSlideAnimations({bool fromTop = false}) {
+    _enterController =
+        AnimationController(vsync: this, duration: _chipAnimDuration)
+          ..forward();
+    _exitController =
+        AnimationController(vsync: this, duration: _chipAnimDuration);
+
+    final enterBegin = fromTop ? const Offset(0, -0.1) : const Offset(0, 0.1);
+    final exitEnd = fromTop ? const Offset(0, -0.1) : const Offset(0, 0.1);
+
+    _enterSlide = Tween<Offset>(begin: enterBegin, end: Offset.zero).animate(
+        CurvedAnimation(parent: _enterController, curve: Curves.easeOut));
+    _exitSlide = Tween<Offset>(begin: Offset.zero, end: exitEnd).animate(
+        CurvedAnimation(parent: _exitController, curve: Curves.easeIn));
+  }
+
+  void disposeSlideAnimations() {
+    _enterController.dispose();
+    _exitController.dispose();
+  }
+
+  void triggerExit() {
+    if (!mounted) return;
+    if (_exitController.isAnimating || _exitController.isCompleted) return;
+    _exitController.forward().then((_) {
+      if (mounted) _onExitComplete();
+    });
+  }
+
+  void _onExitComplete();
+
+  Widget buildSliding({required Widget child}) {
+    return AnimatedBuilder(
+      animation: Listenable.merge([_enterController, _exitController]),
+      builder: (context, innerChild) {
+        final screenH = MediaQuery.sizeOf(context).height;
+        final dy = (_enterSlide.value.dy + _exitSlide.value.dy) * screenH;
+        return Transform.translate(offset: Offset(0, dy), child: innerChild);
+      },
+      child: child,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared chip container
+
+/// Shared container for command-log and error chips: a [DecoratedBox] with
+/// standard horizontal/vertical padding.
+class _ChipBox extends StatelessWidget {
+  const _ChipBox({required this.decoration, required this.child});
+
+  final BoxDecoration decoration;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: decoration,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+        child: child,
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Ghost overlay state
 
 class _GhostOverlayState extends State<_GhostOverlayWidget> {
@@ -442,11 +566,59 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
     super.dispose();
   }
 
+  Widget _buildBannerPainter() {
+    return Positioned.fill(
+      child: CustomPaint(
+        painter: BannerPainter(
+          message: 'slipstream',
+          textDirection: TextDirection.ltr,
+          layoutDirection: TextDirection.ltr,
+          location: BannerLocation.topEnd,
+          color: ghostOverlayColor,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildErrorBanner(double topInset) {
+    return Positioned(
+      top: topInset + 16,
+      left: 12,
+      right: 12,
+      child: _ErrorBanner(
+        key: _errorBannerKey,
+        count: _errorCount,
+        summary: _errorSummary,
+        onExited: _onErrorBannerExited,
+      ),
+    );
+  }
+
+  Widget _buildChips(double bottomInset) {
+    return Positioned(
+      bottom: bottomInset + 36,
+      left: 12,
+      right: 12,
+      child: Stack(
+        alignment: Alignment.center,
+        clipBehavior: Clip.none,
+        children: [
+          for (final entry in _entries)
+            _EntryChip(
+              key: _chipKeys[entry.id],
+              entry: entry,
+              onExited: () => _onChipExited(entry),
+            ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     if (!_visible) return const SizedBox.shrink();
 
-    final bottomInset = MediaQuery.maybePaddingOf(context)?.bottom ?? 0.0;
+    final padding = MediaQuery.maybePaddingOf(context) ?? EdgeInsets.zero;
 
     return IgnorePointer(
       child: Stack(
@@ -466,50 +638,12 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
           _SemanticsOverlay(
               rects: _semanticsRects, triggerCount: _semanticsCount),
           // Slipstream banner — replaces the Flutter debug banner.
-          Positioned.fill(
-            child: CustomPaint(
-              painter: BannerPainter(
-                message: 'slipstream',
-                textDirection: TextDirection.ltr,
-                layoutDirection: TextDirection.ltr,
-                location: BannerLocation.topEnd,
-                color: ghostOverlayColor,
-              ),
-            ),
-          ),
+          _buildBannerPainter(),
           // Persistent error banner near the top of the screen.
-          if (_showErrorBanner)
-            Positioned(
-              top: (MediaQuery.maybePaddingOf(context)?.top ?? 0.0) + 16,
-              left: 12,
-              right: 12,
-              child: _ErrorBanner(
-                key: _errorBannerKey,
-                count: _errorCount,
-                summary: _errorSummary,
-                onExited: _onErrorBannerExited,
-              ),
-            ),
+          if (_showErrorBanner) _buildErrorBanner(padding.top),
           // Command-log chips — share the same space; newer chips are
           // painted in front of older ones.
-          if (_entries.isNotEmpty)
-            Positioned(
-              bottom: bottomInset + 36,
-              left: 12,
-              right: 12,
-              child: Stack(
-                alignment: Alignment.center,
-                clipBehavior: Clip.none,
-                children: [
-                  for (final entry in _entries)
-                    _EntryChip(
-                      key: _chipKeys[entry.id],
-                      entry: entry,
-                      onExited: () => _onChipExited(entry),
-                    ),
-                ],
-              ),
-            ),
+          if (_entries.isNotEmpty) _buildChips(padding.bottom),
         ],
       ),
     );
@@ -785,27 +919,6 @@ class _SemanticsNodeWidget extends StatelessWidget {
 // ---------------------------------------------------------------------------
 // Persistent error banner
 
-const Color _errorColor = Color(0xFFB71C1C);
-
-const TextStyle _errorTextStyle = TextStyle(
-  color: Color(0xFFFFFFFF),
-  fontSize: 12 * 0.85,
-  fontWeight: FontWeight.w900,
-  decoration: TextDecoration.none,
-);
-
-final BoxDecoration _errorDecoration = BoxDecoration(
-  color: _errorColor,
-  borderRadius: BorderRadius.circular(6),
-  boxShadow: const [
-    BoxShadow(
-      color: Color(0x55000000),
-      blurRadius: 6,
-      offset: Offset(0, 2),
-    ),
-  ],
-);
-
 class _ErrorBanner extends StatefulWidget {
   const _ErrorBanner({
     super.key,
@@ -823,44 +936,19 @@ class _ErrorBanner extends StatefulWidget {
 }
 
 class _ErrorBannerState extends State<_ErrorBanner>
-    with TickerProviderStateMixin {
-  static const Duration _animDuration = Duration(milliseconds: 280);
-
-  late final AnimationController _enterController;
-  late final AnimationController _exitController;
-  late final Animation<Offset> _enterSlide;
-  late final Animation<Offset> _exitSlide;
-
+    with TickerProviderStateMixin, _SlidingChipMixin<_ErrorBanner> {
   @override
   void initState() {
     super.initState();
-    _enterController = AnimationController(vsync: this, duration: _animDuration)
-      ..forward();
-    _exitController = AnimationController(vsync: this, duration: _animDuration);
-
-    _enterSlide = Tween<Offset>(
-      begin: const Offset(0, -0.1),
-      end: Offset.zero,
-    ).animate(CurvedAnimation(parent: _enterController, curve: Curves.easeOut));
-
-    _exitSlide = Tween<Offset>(
-      begin: Offset.zero,
-      end: const Offset(0, -0.1),
-    ).animate(CurvedAnimation(parent: _exitController, curve: Curves.easeIn));
-  }
-
-  void triggerExit() {
-    if (!mounted) return;
-    if (_exitController.isAnimating || _exitController.isCompleted) return;
-    _exitController.forward().then((_) {
-      if (mounted) widget.onExited();
-    });
+    initSlideAnimations(fromTop: true);
   }
 
   @override
+  void _onExitComplete() => widget.onExited();
+
+  @override
   void dispose() {
-    _enterController.dispose();
-    _exitController.dispose();
+    disposeSlideAnimations();
     super.dispose();
   }
 
@@ -870,13 +958,7 @@ class _ErrorBannerState extends State<_ErrorBanner>
         ? 'flutter.error'
         : 'flutter.error: ${widget.summary}';
 
-    return AnimatedBuilder(
-      animation: Listenable.merge([_enterController, _exitController]),
-      builder: (context, child) {
-        final screenH = MediaQuery.sizeOf(context).height;
-        final dy = (_enterSlide.value.dy + _exitSlide.value.dy) * screenH;
-        return Transform.translate(offset: Offset(0, dy), child: child);
-      },
+    return buildSliding(
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -885,34 +967,30 @@ class _ErrorBannerState extends State<_ErrorBanner>
             decoration: BoxDecoration(
               color: _errorColor,
               borderRadius: BorderRadius.circular(50),
-              boxShadow: _errorDecoration.boxShadow,
+              boxShadow: _chipBoxShadow,
             ),
             constraints: const BoxConstraints(minWidth: 22, minHeight: 22),
             padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
             alignment: Alignment.center,
-            child: Text('${widget.count}', style: _errorTextStyle),
+            child: Text('${widget.count}', style: _chipTextStyle),
           ),
           const SizedBox(width: 4),
           // error icon and message — centered in remaining space
-          DecoratedBox(
-            decoration: _errorDecoration,
-            child: Padding(
-              padding:
-                  const EdgeInsets.only(left: 8, right: 8, top: 1, bottom: 3),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(Icons.error_outline,
-                      size: 11, color: Color(0xFFFFFFFF)),
-                  const SizedBox(width: 4),
-                  Text(
-                    errorDesc,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: _errorTextStyle,
-                  ),
-                ],
-              ),
+          _ChipBox(
+            decoration: _errorChipDecoration,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.error_outline,
+                    size: 11, color: Color(0xFFFFFFFF)),
+                const SizedBox(width: 4),
+                Text(
+                  errorDesc,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: _chipTextStyle,
+                ),
+              ],
             ),
           ),
         ],
@@ -934,47 +1012,20 @@ class _EntryChip extends StatefulWidget {
   State<_EntryChip> createState() => _EntryChipState();
 }
 
-class _EntryChipState extends State<_EntryChip> with TickerProviderStateMixin {
-  late final AnimationController _enterController;
-  late final AnimationController _exitController;
-  late final Animation<Offset> _enterSlide;
-  late final Animation<Offset> _exitSlide;
-
+class _EntryChipState extends State<_EntryChip>
+    with TickerProviderStateMixin, _SlidingChipMixin<_EntryChip> {
   @override
   void initState() {
     super.initState();
-
-    _enterController =
-        AnimationController(vsync: this, duration: GhostOverlay._toastDuration)
-          ..forward();
-    _exitController =
-        AnimationController(vsync: this, duration: GhostOverlay._toastDuration);
-
-    // Values are fractions of the screen height (0.1 = 10% of screen height).
-    _enterSlide = Tween<Offset>(
-      begin: const Offset(0, 0.1),
-      end: Offset.zero,
-    ).animate(CurvedAnimation(parent: _enterController, curve: Curves.easeOut));
-
-    _exitSlide = Tween<Offset>(
-      begin: Offset.zero,
-      end: const Offset(0, 0.1),
-    ).animate(CurvedAnimation(parent: _exitController, curve: Curves.easeIn));
-  }
-
-  /// Plays the exit animation then calls [_EntryChip.onExited].
-  void triggerExit() {
-    if (!mounted) return;
-    if (_exitController.isAnimating || _exitController.isCompleted) return;
-    _exitController.forward().then((_) {
-      if (mounted) widget.onExited();
-    });
+    initSlideAnimations();
   }
 
   @override
+  void _onExitComplete() => widget.onExited();
+
+  @override
   void dispose() {
-    _enterController.dispose();
-    _exitController.dispose();
+    disposeSlideAnimations();
     super.dispose();
   }
 
@@ -993,54 +1044,23 @@ class _EntryChipState extends State<_EntryChip> with TickerProviderStateMixin {
         : widget.entry.command;
     final icon = _iconForKind(widget.entry.kind);
 
-    return AnimatedBuilder(
-      animation: Listenable.merge([_enterController, _exitController]),
-      builder: (context, child) {
-        final screenH = MediaQuery.sizeOf(context).height;
-        final dy = (_enterSlide.value.dy + _exitSlide.value.dy) * screenH;
-        return Transform.translate(offset: Offset(0, dy), child: child);
-      },
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color.alphaBlend(const Color(0x28FFFFFF), ghostOverlayColor),
-              ghostOverlayColor,
+    return buildSliding(
+      child: _ChipBox(
+        decoration: _logChipDecoration,
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (icon != null) ...[
+              Icon(icon, size: 11, color: const Color(0xFFFFFFFF)),
+              const SizedBox(width: 4),
             ],
-          ),
-          borderRadius: BorderRadius.circular(6),
-          boxShadow: const [
-            BoxShadow(
-              color: Color(0x55000000),
-              blurRadius: 6,
-              offset: Offset(0, 2),
+            Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: _chipTextStyle,
             ),
           ],
-        ),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (icon != null) ...[
-                Icon(icon, size: 11, color: const Color(0xFFFFFFFF)),
-                const SizedBox(width: 4),
-              ],
-              Text(
-                label,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  color: Color(0xFFFFFFFF),
-                  fontSize: 12 * 0.85,
-                  fontWeight: FontWeight.w900,
-                  decoration: TextDecoration.none,
-                ),
-              ),
-            ],
-          ),
         ),
       ),
     );

--- a/slipstream_agent/lib/src/ghost_overlay.dart
+++ b/slipstream_agent/lib/src/ghost_overlay.dart
@@ -47,7 +47,7 @@ class GhostOverlay {
 
   // Persistent error state — source of truth; the widget state mirrors this.
   static int _errorCount = 0;
-  static String _errorSummary = '';
+  static String? _errorSummary;
 
   /// Records a new `flutter.error` event and shows the persistent error banner.
   ///
@@ -57,15 +57,15 @@ class GhostOverlay {
   static void showError(String summary) {
     _errorCount++;
     _errorSummary = summary;
-    _key.currentState?.setError(_errorCount, _errorSummary);
+    _key.currentState?.syncErrorBanner();
     _ensureInstalled();
   }
 
   /// Clears the persistent error banner.
   static void clearErrors() {
     _errorCount = 0;
-    _errorSummary = '';
-    _key.currentState?.setError(0, '');
+    _errorSummary = null;
+    _key.currentState?.syncErrorBanner();
   }
 
   /// Installs the ghost overlay and permanently disables the Flutter debug
@@ -171,7 +171,7 @@ class GhostOverlay {
       _pending.clear();
     }
     if (_errorCount > 0) {
-      state.setError(_errorCount, _errorSummary);
+      state.syncErrorBanner();
     }
   }
 
@@ -366,19 +366,21 @@ mixin _SlidingChipMixin<T extends StatefulWidget>
 /// Shared container for command-log and error chips: a [DecoratedBox] with
 /// standard horizontal/vertical padding.
 class _ChipBox extends StatelessWidget {
-  const _ChipBox({required this.decoration, required this.child});
+  const _ChipBox({
+    required this.decoration,
+    required this.child,
+    this.padding = const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+  });
 
   final BoxDecoration decoration;
   final Widget child;
+  final EdgeInsets padding;
 
   @override
   Widget build(BuildContext context) {
     return DecoratedBox(
       decoration: decoration,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
-        child: child,
-      ),
+      child: Padding(padding: padding, child: child),
     );
   }
 }
@@ -397,15 +399,23 @@ class _GhostOverlayState extends State<_GhostOverlayWidget> {
   final GlobalKey<_ErrorBannerState> _errorBannerKey = GlobalKey();
   bool _showErrorBanner = false;
   int _errorCount = 0;
-  String _errorSummary = '';
+  String? _errorSummary;
 
-  void setError(int count, String summary) {
+  void syncErrorBanner() {
     if (!mounted) return;
-    if (count > 0) {
-      setState(() {
-        _errorCount = count;
-        _errorSummary = summary;
-        _showErrorBanner = true;
+
+    if (GhostOverlay._errorCount > 0) {
+      // Defer setState — FlutterError.onError fires during layout/paint
+      // (e.g. overflow errors), and setState is illegal during a frame.
+      // Reading from GhostOverlay statics in the callback captures the latest
+      // value even if multiple errors arrive in the same frame.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        setState(() {
+          _errorCount = GhostOverlay._errorCount;
+          _errorSummary = GhostOverlay._errorSummary;
+          _showErrorBanner = true;
+        });
       });
     } else {
       _errorBannerKey.currentState?.triggerExit();
@@ -970,27 +980,36 @@ class _ErrorBannerState extends State<_ErrorBanner>
               boxShadow: _chipBoxShadow,
             ),
             constraints: const BoxConstraints(minWidth: 22, minHeight: 22),
-            padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
+            padding:
+                const EdgeInsets.only(left: 5, right: 5, top: 1, bottom: 3),
             alignment: Alignment.center,
             child: Text('${widget.count}', style: _chipTextStyle),
           ),
+
           const SizedBox(width: 4),
-          // error icon and message — centered in remaining space
-          _ChipBox(
-            decoration: _errorChipDecoration,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                const Icon(Icons.error_outline,
-                    size: 11, color: Color(0xFFFFFFFF)),
-                const SizedBox(width: 4),
-                Text(
-                  errorDesc,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: _chipTextStyle,
-                ),
-              ],
+
+          // error icon and message — Flexible so text truncates if needed
+          Flexible(
+            child: _ChipBox(
+              decoration: _errorChipDecoration,
+              padding:
+                  const EdgeInsets.only(left: 8, right: 8, top: 1, bottom: 3),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Icon(Icons.error_outline,
+                      size: 11, color: Color(0xFFFFFFFF)),
+                  const SizedBox(width: 4),
+                  Flexible(
+                    child: Text(
+                      errorDesc,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: _chipTextStyle,
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
         ],

--- a/slipstream_agent/lib/src/telemetry.dart
+++ b/slipstream_agent/lib/src/telemetry.dart
@@ -1,51 +1,8 @@
-import 'dart:async';
-import 'dart:developer' show postEvent;
-
-import 'package:flutter/widgets.dart';
-
 /// Registers framework observers that broadcast structured JSON events to VM
 /// service clients via [postEvent].
 ///
-/// Call once from [Agent.initialize]. Safe to call multiple times — the
-/// observer is only added once.
-void initTelemetry() {
-  WidgetsBinding.instance.addObserver(_observer);
-}
-
-final _SlipstreamObserver _observer = _SlipstreamObserver();
-
-class _SlipstreamObserver extends WidgetsBindingObserver {
-  Timer? _previousEvent;
-
-  /// Fires whenever the window metrics change (resize, rotation, DPR change).
-  ///
-  /// Posts `ext.slipstream.windowResized` with the logical and physical
-  /// dimensions of the implicit view.
-  @override
-  void didChangeMetrics() {
-    final view = WidgetsBinding.instance.platformDispatcher.implicitView;
-    if (view == null) {
-      return;
-    }
-
-    _previousEvent?.cancel();
-
-    final physicalSize = view.physicalSize;
-    final dpr = view.devicePixelRatio;
-
-    final data = {
-      'viewId': view.viewId,
-      'physicalWidth': physicalSize.width,
-      'physicalHeight': physicalSize.height,
-      'devicePixelRatio': dpr,
-      'logicalWidth': physicalSize.width / dpr,
-      'logicalHeight': physicalSize.height / dpr,
-    };
-
-    // De-bounce the event - when resizing a window we generate a large number
-    // of notifications.
-    _previousEvent = Timer(const Duration(milliseconds: 100), () {
-      postEvent('ext.slipstream.windowResized', data);
-    });
-  }
-}
+/// Call once from [Agent.initialize]. Safe to call multiple times.
+///
+/// New telemetry events go here; register any observer hooks and document in
+/// `docs/service_extensions.md`.
+void initTelemetry() {}

--- a/slipstream_agent/lib/src/telemetry.dart
+++ b/slipstream_agent/lib/src/telemetry.dart
@@ -1,8 +1,27 @@
-/// Registers framework observers that broadcast structured JSON events to VM
-/// service clients via [postEvent].
+import 'package:flutter/widgets.dart';
+
+import 'ghost_overlay.dart';
+
+/// Registers framework hooks that surface Flutter errors in the ghost overlay.
 ///
-/// Call once from [Agent.initialize]. Safe to call multiple times.
+/// Must be called exactly once — wraps [FlutterError.onError] and is not
+/// idempotent. The call site ([Agent.initialize]) guards against re-entry.
 ///
-/// New telemetry events go here; register any observer hooks and document in
-/// `docs/service_extensions.md`.
-void initTelemetry() {}
+/// New telemetry hooks go here; document in `docs/service_extensions.md`.
+void initTelemetry() {
+  final upstream = FlutterError.onError;
+  FlutterError.onError = (FlutterErrorDetails details) {
+    upstream?.call(details);
+    GhostOverlay.showError(_extractErrorSummary(details));
+  };
+}
+
+String _extractErrorSummary(FlutterErrorDetails details) {
+  final msg = details.exceptionAsString();
+  final first = msg.split('\n').firstWhere(
+    (l) => l.trim().isNotEmpty,
+    orElse: () => msg,
+  );
+  final trimmed = first.trim();
+  return trimmed.length > 40 ? '${trimmed.substring(0, 38)}…' : trimmed;
+}

--- a/slipstream_agent/lib/src/telemetry.dart
+++ b/slipstream_agent/lib/src/telemetry.dart
@@ -19,9 +19,10 @@ void initTelemetry() {
 String _extractErrorSummary(FlutterErrorDetails details) {
   final msg = details.exceptionAsString();
   final first = msg.split('\n').firstWhere(
-    (l) => l.trim().isNotEmpty,
-    orElse: () => msg,
-  );
+        (l) => l.trim().isNotEmpty,
+        orElse: () => msg,
+      );
   final trimmed = first.trim();
-  return trimmed.length > 40 ? '${trimmed.substring(0, 38)}…' : trimmed;
+  final words = trimmed.split(' ');
+  return words.length <= 3 ? words.join(' ') : '${words.take(3).join(' ')}…';
 }

--- a/slipstream_agent/lib/src/version.dart
+++ b/slipstream_agent/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Keep this version in-sync with pubspec.yaml.
-const String packageVersion = '1.1.1';
+const String packageVersion = '1.2.0';

--- a/slipstream_agent/pubspec.yaml
+++ b/slipstream_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: slipstream_agent
 # Keep this version in-sync with lib/src/version.dart.
-version: 1.1.1
+version: 1.2.0
 description: An in-process companion for the Flutter Slipstream agent tools.
 
 repository: https://github.com/devoncarew/slipstream_agent/tree/main/slipstream_agent


### PR DESCRIPTION
Bundles all 1.2.0-wip work into a single release PR.

- Add `pumpAndMostlySettle()` and call it after `perform_action` and `navigate` so the widget tree settles before the next tool call
- Remove `ext.slipstream.windowResized` (low value — agents would need to poll)
- Add `byTextContaining` finder: matches `Text` whose content contains a substring (useful for truncated display text)
- Add persistent `flutter.error` banner: intercepts `FlutterError.onError` and shows a count badge + summary chip near the top of the screen; clears on hot reload
- Add `ext.slipstream.clear_errors` extension: dismisses the error banner after the agent has read the output
- Fix banner overflow (`Flexible` on the chip) and "setState during build" (defer via `addPostFrameCallback`)
- Refactor `agent.dart`: one `AgentExtension` subclass per extension
- Refactor `ghost_overlay.dart`: shared constants, `_SlidingChipMixin`, `_ChipBox`, and build helpers
- closes https://github.com/devoncarew/slipstream_agent/issues/27; closes https://github.com/devoncarew/slipstream_agent/issues/23; closes https://github.com/devoncarew/slipstream_agent/issues/29; closes https://github.com/devoncarew/slipstream_agent/issues/25
