### PR TITLE
Improve scroll toast display and fix scroll_until_visible for lists

### DIFF
--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1-wip
+
+- For the 'scroll: xx px' toast, display the scroll rounded to the nearest int.
+
 ## 1.2.0
 
 - `ext.slipstream.perform_action` and `ext.slipstream.navigate` now wait for the

--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.1-wip
+## 1.2.1
 
 - Fix `scroll_until_visible` for lazy/virtual lists: the target finder is now
   re-evaluated after each scroll step so that `ListView.builder` items are

--- a/slipstream_agent/CHANGELOG.md
+++ b/slipstream_agent/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.2.1-wip
 
+- Fix `scroll_until_visible` for lazy/virtual lists: the target finder is now
+  re-evaluated after each scroll step so that `ListView.builder` items are
+  discovered as they enter the render tree. Previously the element was looked up
+  once before scrolling began, causing the action to fail immediately for any
+  item not yet built.
 - For the 'scroll: xx px' toast, display the scroll rounded to the nearest int.
 
 ## 1.2.0

--- a/slipstream_agent/lib/src/actions.dart
+++ b/slipstream_agent/lib/src/actions.dart
@@ -3,6 +3,8 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/widgets.dart';
 
+import 'finder.dart';
+
 /// Synthesizes a tap at the center of [element]'s render box.
 ///
 /// Returns null on success, or an error message on failure. The tap is
@@ -88,13 +90,15 @@ Future<String?> scrollElement(
   return null;
 }
 
-/// Scrolls the [Scrollable] at [scrollElement] until [targetElement] is
-/// visible in the viewport.
+/// Scrolls the [Scrollable] at [scrollableElement] until the widget matched by
+/// [targetFinder]/[targetFinderValue] is visible in the viewport.
 ///
-/// Both elements must be located in the tree before calling this. Returns null
-/// on success, or an error message on failure.
+/// The finder is re-evaluated after each scroll step so that lazily-built
+/// widgets (e.g. [ListView.builder] items) are discovered as they enter the
+/// render tree. Returns null on success, or an error message on failure.
 Future<String?> scrollUntilVisible({
-  required Element targetElement,
+  required String targetFinder,
+  required String targetFinderValue,
   required Element scrollableElement,
 }) async {
   final ScrollableState? scrollState = _findScrollableState(scrollableElement);
@@ -107,27 +111,28 @@ Future<String?> scrollUntilVisible({
   const double stepPixels = 200.0;
 
   for (var i = 0; i < maxSteps; i++) {
-    // Check if target is now visible.
-    final RenderBox? targetBox = _findRenderBox(targetElement);
-    if (targetBox != null && targetBox.hasSize) {
-      final RenderAbstractViewport? viewport =
-          RenderAbstractViewport.maybeOf(targetBox);
-      if (viewport != null) {
-        final RevealedOffset revealed =
-            viewport.getOffsetToReveal(targetBox, 0.5);
-        final double current = scrollState.position.pixels;
-        final double target = revealed.offset;
-        if ((current - target).abs() < 1.0) break; // already visible
-        scrollState.position.jumpTo(
-          target.clamp(
-            scrollState.position.minScrollExtent,
-            scrollState.position.maxScrollExtent,
-          ),
-        );
-        break;
+    // Re-search on every iteration: lazy lists build new elements as we scroll.
+    final targetElement =
+        findElement(finder: targetFinder, value: targetFinderValue);
+    if (targetElement != null) {
+      final RenderBox? targetBox = _findRenderBox(targetElement);
+      if (targetBox != null && targetBox.hasSize) {
+        final RenderAbstractViewport? viewport =
+            RenderAbstractViewport.maybeOf(targetBox);
+        if (viewport != null) {
+          final RevealedOffset revealed =
+              viewport.getOffsetToReveal(targetBox, 0.5);
+          scrollState.position.jumpTo(
+            revealed.offset.clamp(
+              scrollState.position.minScrollExtent,
+              scrollState.position.maxScrollExtent,
+            ),
+          );
+          return null; // found and revealed
+        }
       }
     }
-    // Target not yet laid out or no viewport — scroll down a step and retry.
+    // Target not yet in the tree or not laid out — scroll a step and retry.
     final double next = (scrollState.position.pixels + stepPixels).clamp(
       scrollState.position.minScrollExtent,
       scrollState.position.maxScrollExtent,
@@ -138,7 +143,7 @@ Future<String?> scrollUntilVisible({
     await SchedulerBinding.instance.endOfFrame;
   }
 
-  return null;
+  return 'scroll_until_visible: "$targetFinderValue" not found after scrolling';
 }
 
 /// Finds the first [ScrollableState] at or below [element].

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -297,7 +297,7 @@ class _PerformActionExtension extends AgentExtension {
           error = 'interact: "pixels" is required for the scroll action';
         } else {
           GhostOverlay.log('scroll',
-              details: '$direction ${pixels}px',
+              details: '$direction ${pixels.round()}px',
               kind: 'interact',
               finder: finder,
               finderValue: finderValue,

--- a/slipstream_agent/lib/src/agent.dart
+++ b/slipstream_agent/lib/src/agent.dart
@@ -259,8 +259,13 @@ class _PerformActionExtension extends AgentExtension {
     final String? scrollFinder = parameters.asString('scrollFinder');
     final String? scrollFinderValue = parameters.asString('scrollFinderValue');
 
-    final element = findElement(finder: finder, value: finderValue);
-    if (element == null) {
+    // For scroll_until_visible the target may not be in the tree yet (lazy
+    // list), so we defer the lookup to scrollUntilVisible itself. All other
+    // actions require the element to be present up front.
+    final element = action == 'scroll_until_visible'
+        ? null
+        : findElement(finder: finder, value: finderValue);
+    if (element == null && action != 'scroll_until_visible') {
       return {
         'ok': false,
         'error': 'interact: no element found for finder="$finder" '
@@ -277,7 +282,7 @@ class _PerformActionExtension extends AgentExtension {
             finder: finder,
             finderValue: finderValue,
             viz: 'outline');
-        error = await tapElement(element);
+        error = await tapElement(element!);
       case 'set_text':
         if (text == null) {
           error = 'interact: "text" is required for the set_text action';
@@ -288,7 +293,7 @@ class _PerformActionExtension extends AgentExtension {
               finder: finder,
               finderValue: finderValue,
               viz: 'outline');
-          error = setTextInElement(element, text);
+          error = setTextInElement(element!, text);
         }
       case 'scroll':
         if (direction == null) {
@@ -303,7 +308,7 @@ class _PerformActionExtension extends AgentExtension {
               finderValue: finderValue,
               viz: 'outline');
           error = await scrollElement(
-            element,
+            element!,
             direction: direction,
             pixels: pixels,
           );
@@ -330,7 +335,8 @@ class _PerformActionExtension extends AgentExtension {
                 finderValue: finderValue,
                 viz: 'outline');
             error = await scrollUntilVisible(
-              targetElement: element,
+              targetFinder: finder,
+              targetFinderValue: finderValue,
               scrollableElement: scrollable,
             );
           }

--- a/slipstream_agent/lib/src/version.dart
+++ b/slipstream_agent/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Keep this version in-sync with pubspec.yaml.
-const String packageVersion = '1.2.0';
+const String packageVersion = '1.2.1';

--- a/slipstream_agent/pubspec.yaml
+++ b/slipstream_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: slipstream_agent
 # Keep this version in-sync with lib/src/version.dart.
-version: 1.2.1-wip
+version: 1.2.1
 description: An in-process companion for the Flutter Slipstream agent tools.
 
 repository: https://github.com/devoncarew/slipstream_agent/tree/main/slipstream_agent

--- a/slipstream_agent/pubspec.yaml
+++ b/slipstream_agent/pubspec.yaml
@@ -1,6 +1,6 @@
 name: slipstream_agent
 # Keep this version in-sync with lib/src/version.dart.
-version: 1.2.0
+version: 1.2.1-wip
 description: An in-process companion for the Flutter Slipstream agent tools.
 
 repository: https://github.com/devoncarew/slipstream_agent/tree/main/slipstream_agent


### PR DESCRIPTION
- Fix `scroll_until_visible` for lazy/virtual lists: the target finder is now re-evaluated after each scroll step so that `ListView.builder` items are discovered as they enter the render tree. Previously the element was looked up once before scrolling began, causing the action to fail immediately for any item not yet built.
- For the 'scroll: xx px' toast, display the scroll rounded to the nearest int.
- fix https://github.com/devoncarew/slipstream_agent/issues/26
- prep to publish 1.2.1

